### PR TITLE
fix(webhook): remove media stub duplicado (imagem chegava null no CRM)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -240,12 +240,6 @@ whastapp.onMessageReceived(async (message: MessageReceived) => {
       message.message?.locationMessage?.comment ||
       message.message?.liveLocationMessage?.caption ||
       null,
-    media: {
-      image: null, // TODO: implement media handling
-      video: null,
-      document: null,
-      audio: null,
-    },
   };
   console.log(body);
   


### PR DESCRIPTION
## Bug
No body do webhook (src/index.ts) havia DUAS chaves `media`: a real (com `{kind,data(base64),mimetype,filename,caption}` da imagem/documento baixado) e, logo abaixo, um stub `media:{image:null,video:null,document:null,audio:null}` (TODO). Em JS a ultima chave vence -> o CRM sempre recebia `media:null` e nao conseguia anexar a foto enviada pelo WhatsApp.

## Fix
Remove o stub. Vai o `media` real (ja baixado logo acima). O CRM (parseMedia) ja sabe ler esse formato -> storePendingMedia + tool anexarMidiaPendente fecham o anexo.

Diagnostico: log do CRM mostrava media.image=null; media/ vazio; index.ts com chave duplicada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)