### PR TITLE
feat(bridge): ponte multi-canal (Meta + Teams) + registrar tenant em runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Sem `version:` de propósito — a action lê o campo `packageManager` do
+      # package.json. Assim CI, Docker e máquina local usam o MESMO pnpm, e o
+      # lockfile para de mudar de forma dependendo de quem rodou o install.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+# O repo tinha deploy (deploy.yml) mas nenhuma verificação antes dele: os testes
+# da ponte só rodavam na máquina de quem escreveu. Num serviço que atende
+# WhatsApp de cliente, "passou aqui" não pode ser a garantia.
+on:
+  pull_request:
+  push:
+    branches: [master, hml]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      # --frozen-lockfile: falha se o pnpm-lock.yaml não bater com o
+      # package.json. É o que impede uma resolução diferente de dependência
+      # entrar em produção sem ninguém ter decidido isso — foi assim que o
+      # audio-decode (peer opcional do Baileys) sumiu do lockfile sem intenção.
+      - name: Instalar dependências
+        run: pnpm install --frozen-lockfile
+
+      - name: Testes
+        run: pnpm test
+
+      # Só os módulos da ponte: o resto do repo é código herdado do upstream
+      # (mimamch/wa-gateway) e tem erros de tipo pré-existentes que não são
+      # nossos pra corrigir agora. Travar o que é nosso já evita regressão.
+      - name: Typecheck dos módulos da ponte
+        run: pnpm exec tsc --noEmit -p . 2>&1 | (! grep -E "src/bridge/|src/env\.ts")

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,12 @@ jobs:
       PORT: ${{ vars.PORT }}
       # Bridge multi-canal (contém tokens → secret, não var)
       BRIDGE_TENANTS: ${{ secrets.BRIDGE_TENANTS }}
+      # Token que a plataforma de agentes usa pra REGISTRAR o tenant de um bot
+      # novo em runtime (PUT /bridge/tenants/<nome>), sem reiniciar este serviço.
+      # Reiniciar derruba a ponte de todos os bots no ar — era o que tornava
+      # "criar bot em prd" impossível de fazer sem incomodar quem já usa.
+      # Precisa ser o MESMO valor do BRIDGE_ADMIN_TOKEN do agent-platform.
+      BRIDGE_ADMIN_TOKEN: ${{ secrets.BRIDGE_ADMIN_TOKEN }}
     steps:
       - name: Ensure project directory exists and clean
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@
 FROM node:20-alpine AS base
 
 # Install pnpm
-RUN npm install -g pnpm
+# Versão FIXA: `npm i -g pnpm` pega a latest, então dois builds em datas
+# diferentes podiam resolver dependências de formas diferentes — foi assim que o
+# audio-decode saiu do lockfile sem ninguém decidir. Casada com o
+# `packageManager` do package.json.
+RUN npm install -g pnpm@11.1.3
 
 # Build stage
 FROM base AS builder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,13 @@ services:
       - DB_PATH=/app/db/wa_gateway.db
       # Bridge multi-canal (ponte /ingress/:tenant + /bridge/agent)
       - BRIDGE_TENANTS=${BRIDGE_TENANTS:-}
+      # Autoriza a plataforma de agentes a REGISTRAR tenant em runtime
+      # (PUT /bridge/tenants/<nome>), sem reiniciar este processo — reiniciar
+      # derruba a ponte de todos os bots que estão no ar. Tem que ser o mesmo
+      # valor configurado como BRIDGE_ADMIN_TOKEN no control-plane.
+      # Vazio = rotas de registro desligadas (fail-closed); só vale o
+      # BRIDGE_TENANTS do env, como era antes.
+      - BRIDGE_ADMIN_TOKEN=${BRIDGE_ADMIN_TOKEN:-}
     
     volumes:
       # Mount WhatsApp credentials directory

--- a/docs/teams-bot/00-visao-geral.md
+++ b/docs/teams-bot/00-visao-geral.md
@@ -1,0 +1,66 @@
+# 00 — Visão geral (o "cano")
+
+## Diferença que confunde: Azure ≠ instalar no Teams
+
+Duas coisas separadas, ambas necessárias:
+
+1. **Registro no Azure** = o "cérebro/motor" do bot. É a identidade, a credencial
+   e o **endereço** (endpoint) pra onde o Teams manda as mensagens. Criado uma vez.
+2. **Pacote do app no Teams** (manifest zip) = o "atalho de instalação". Faz o bot
+   **aparecer** no cliente Teams de alguém pra poder conversar. Sem instalar, o bot
+   existe no Azure mas ninguém tem onde clicar pra falar com ele.
+
+Analogia: Azure é o motor do carro (pronto). O zip é a chave que dá acesso. É o
+**mesmo carro** — o zip só aponta pro bot que já existe no Azure.
+
+## O fluxo ponta a ponta
+
+```
+Usuário no Teams
+      │  (manda "oi")
+      ▼
+Microsoft Bot Framework (nuvem MS)
+      │  POST pro endpoint do bot (Activity JSON, assinado com JWT)
+      ▼
+Endpoint público  ──►  https://<tunel>/ingress/teams-teste
+      │                (em local: cloudflared; em prd: wa-gateway.odd.com.br)
+      ▼
+wa-gateway
+      │  1. adaptador teams.ts valida o JWT e traduz a Activity
+      │  2. hub roteia pro tenant "teams-teste"
+      ▼
+Bridge WebSocket  ──►  /bridge/agent?token=<wsToken>
+      │                (o agente/shim está conectado aqui, "puxando" mensagens)
+      ▼
+Agente (hoje: shim de teste; amanhã: Claude da plataforma)
+      │  decide a resposta
+      ▼
+volta pelo mesmo WS  ──►  wa-gateway  ──►  serviceUrl do Teams
+      │                (token AAD client_credentials pra postar de volta)
+      ▼
+Usuário vê a resposta no Teams
+```
+
+## Por que wa-gateway e não Teams "direto"?
+
+- O Teams (Bot Framework) exige **rota pública** pra empurrar mensagens (webhook).
+  A plataforma de agentes roda os bots em containers **sem porta inbound** (Telegram
+  funciona por long-poll, que não precisa de rota pública).
+- O wa-gateway **já resolve isso** pro WhatsApp: recebe o webhook público, valida,
+  e entrega pro agente por uma **ponte WebSocket** (o agente disca pra fora). Mesmo
+  padrão serve pro Teams — só trocamos o adaptador de entrada.
+- Ganho: um único ponto público (wa-gateway) atende N bots (WhatsApp, Teams…), cada
+  um isolado por "tenant". O agente continua sem abrir porta.
+
+## Peças
+
+| Peça | Papel | Onde roda |
+|------|-------|-----------|
+| App registration (Entra) | identidade + credencial do bot | Azure |
+| Azure Bot + canal MsTeams | registra o endpoint, liga o canal Teams | Azure |
+| Manifest zip | app do Teams (torna o bot instalável/visível) | subido no Teams |
+| wa-gateway | recebe webhook, valida, faz a ponte | local agora / ECS prd |
+| Túnel (cloudflared) | expõe o wa-gateway local numa URL pública | local (só teste) |
+| Agente/shim | decide a resposta | WS client → bridge |
+
+Detalhe de cada uma nos docs seguintes.

--- a/docs/teams-bot/01-azure-setup.md
+++ b/docs/teams-bot/01-azure-setup.md
@@ -1,0 +1,74 @@
+# 01 — Setup no Azure
+
+O que precisa existir no Azure pra um bot de Teams funcionar. Feito **uma vez** por
+bot (depois automatizamos pela plataforma — ver [06](06-integrar-plataforma.md)).
+
+## Os 4 artefatos
+
+1. **App registration (Entra ID / Azure AD)** — a identidade do bot.
+   - Gera um **App ID** (client id). É o `botId` que vai no manifest.
+   - Precisa de um **client secret** (senha) → usado pra pegar token AAD e postar
+     a resposta de volta no Teams.
+   - Tipo: `Multi-tenant` ou `Single-tenant` (usamos single, tenant Limppano
+     `6fdfcb68-...`).
+
+2. **Service Principal** — a materialização do app no tenant (criado junto/consent).
+
+3. **Azure Bot resource** (recurso "Azure Bot" no portal / `az bot create`).
+   - Amarra o App ID ao bot.
+   - Define o **messaging endpoint** = a URL pública que recebe as Activities:
+     `https://<host-publico>/ingress/teams-teste`.
+
+4. **Canal Microsoft Teams** habilitado no Azure Bot (`az bot msteams create`).
+   - Sem isso o Teams não fala com o bot.
+
+## Identidade "manager" (provisionamento)
+
+Pra criar esses artefatos por API (e no futuro, automaticamente pela plataforma),
+usamos um **app de provisionamento** dedicado:
+
+- App `agent-platform-manager` (App ID `47014211-...`), criado no Cloud Shell.
+- Permissões Graph/ARM pra criar app registrations e recursos de bot.
+- **Limitação achada:** app-only **não** tem cargo de admin do Teams → **não**
+  consegue publicar app no catálogo da org (`POST /appCatalogs/teamsApps` → 403
+  Forbidden). Publicar no catálogo exige um humano com cargo Teams Admin, ou
+  atribuir esse cargo à identidade. Ver [02](02-manifest-teams.md).
+
+## Valores do bot de teste (2026-07-28)
+
+> Segredos reais NÃO ficam aqui. Guardar no AWS Secrets Manager quando virar prd.
+
+| Campo | Valor |
+|-------|-------|
+| Nome do Azure Bot | `agent-teams-teste` |
+| botId / App ID | `62d5251f-...` |
+| Tenant | `6fdfcb68-bdb6-4b67-ae6a-2356458c73d0` |
+| Messaging endpoint | `https://<tunel>.trycloudflare.com/ingress/teams-teste` |
+| Canal | MsTeams habilitado |
+| client secret | no cofre (não versionar) |
+
+## Ordem prática (az cli)
+
+```bash
+# 1. app registration + secret
+az ad app create --display-name agent-teams-teste
+az ad app credential reset --id <appId>        # anota a senha
+
+# 2. azure bot + endpoint
+az bot create --resource-group <rg> --name agent-teams-teste \
+  --app-type SingleTenant --appid <appId> --tenant-id <tenant> \
+  --endpoint "https://<host>/ingress/teams-teste"
+
+# 3. canal teams
+az bot msteams create --resource-group <rg> --name agent-teams-teste
+```
+
+## Pegadinhas
+
+- **Endpoint muda quando o túnel muda.** Túnel `cloudflared` gratuito gera URL
+  nova a cada restart. Se reiniciar o túnel, tem que atualizar o endpoint do Azure
+  Bot (`az bot update --endpoint ...`). Em prd isso some (URL fixa do wa-gateway).
+- **Single vs multi-tenant** precisa bater no `az bot create` (`--app-type`) e no
+  jeito de pegar o token AAD depois.
+- Consentimento das permissões do manager teve que ser dado por admin ("já dei as
+  permissões") — app-only não auto-consente.

--- a/docs/teams-bot/02-manifest-teams.md
+++ b/docs/teams-bot/02-manifest-teams.md
@@ -1,0 +1,68 @@
+# 02 — Manifest e pacote do app Teams
+
+O Azure registra o bot, mas ele só **aparece** no Teams de alguém depois de instalar
+o **pacote do app** (um zip). Este doc explica o zip e as formas de instalar.
+
+## O que é o zip
+
+Um `.zip` com 3 arquivos:
+
+- `manifest.json` — descreve o app (id, nome, o `botId`, domínios válidos).
+- `color.png` — ícone colorido 192×192.
+- `outline.png` — ícone contorno 32×32 (transparente).
+
+O `manifest.json` **aponta** pro bot do Azure — não cria bot nenhum. Campos-chave:
+
+```jsonc
+{
+  "manifestVersion": "1.17",
+  "id": "62d5251f-...",              // id do app Teams (pode = botId)
+  "name": { "short": "Agente Teste" },
+  "bots": [{
+    "botId": "62d5251f-...",         // = App ID do Azure (doc 01)
+    "scopes": ["personal"]           // "personal" = chat 1:1
+  }],
+  "validDomains": ["<tunel>.trycloudflare.com"]
+}
+```
+
+- `validDomains` precisa conter o host do endpoint público (senão o Teams bloqueia).
+  Em local = domínio do túnel; em prd = `wa-gateway.odd.com.br`.
+- `scopes: ["personal"]` = conversa privada 1:1. Pra grupos/canais, add `team`/`groupChat`.
+
+Gerar o zip (exemplo usado): `manifest.json` + os 2 PNGs zipados na raiz.
+
+## Como instalar — 3 caminhos
+
+### A) Sideload (upload custom app) — o mais rápido pra teste
+
+No cliente Teams: **Aplicativos → Gerenciar seus aplicativos → Carregar um
+aplicativo → Carregar um aplicativo personalizado** → escolhe o zip.
+
+- Instala **só na tua conta**. Ninguém mais vê.
+- **Requisito:** a política do Teams precisa permitir "upload de apps personalizados"
+  pro usuário. Se o botão não aparece / vem apagado, tá bloqueado → usar caminho B.
+- ⚠️ A tela "Aplicativos → Adicionado pela sua organização" **não** tem botão de
+  upload — ela só lista o que a org já publicou. O upload é em "Gerenciar seus
+  aplicativos".
+
+### B) Publicar no catálogo da org (Teams Admin Center) — "pra 1 pessoa só" de verdade
+
+`admin.teams.microsoft.com` → **Aplicativos do Teams → Gerenciar aplicativos →
+Carregar** → sobe o zip. Depois, numa **política de permissão de app**, libera o
+app só pro usuário/grupo desejado e bloqueia pro resto.
+
+- É o jeito "oficial". Exige cargo **Teams Administrator**.
+- Restringe **quem enxerga/instala**. (Quem o bot **responde** já travamos no
+  código — ver [05](05-controle-acesso.md).)
+
+### C) Publicar por API (Graph) — automação futura
+
+`POST /appCatalogs/teamsApps` com o zip. **Hoje dá 403** com a identidade manager
+(app-only sem cargo Teams Admin). Pra automatizar pela plataforma, resolver o cargo
+antes — ver [06](06-integrar-plataforma.md).
+
+## Resumo mental
+
+- Zip **não** cria bot. Só dá **acesso/visibilidade** ao bot que já existe no Azure.
+- Teste rápido → caminho A. Oficial/restrito → caminho B. Automático → C (pendente).

--- a/docs/teams-bot/03-wa-gateway-bridge.md
+++ b/docs/teams-bot/03-wa-gateway-bridge.md
@@ -1,0 +1,75 @@
+# 03 — Como o wa-gateway faz a ponte
+
+Branch: `feat/meta-cloud-relay`. O wa-gateway é um **relay genérico**: recebe
+webhook de um canal, valida/traduz, e entrega pro agente por uma ponte WebSocket.
+
+## Rotas (src/bridge/controller.ts)
+
+```
+GET  /ingress/:tenant        → handshake (canal decide se usa; Teams NÃO usa)
+POST /ingress/:tenant        → mensagem do canal → adapter valida+parseia → empurra pro WS
+POST /ingress/:tenant/send   → envio por HTTP (auth pelo wsToken) — alternativa ao WS
+GET  /bridge/agent?token=... → o agente conecta aqui (WebSocket) e "puxa" as mensagens
+GET  /bridge/status          → tenants conectados (debug)
+```
+
+Roteia por `:tenant`. **Adicionar um bot/canal = só adicionar config** — o código
+não muda.
+
+## Config: BRIDGE_TENANTS
+
+Um JSON (lido no boot) que mapeia tenant → canal + credenciais + wsToken:
+
+```jsonc
+BRIDGE_TENANTS='[
+  {
+    "name": "teams-teste",
+    "channel": "teams",
+    "wsToken": "<tok-gerado>",            // segredo do agente pra conectar no bridge
+    "config": {
+      "appId":       "62d5251f-...",       // App ID do bot (doc 01)
+      "appPassword": "<secret>",            // client secret do bot
+      "tenantId":    "6fdfcb68-..."         // tenant AAD (single-tenant)
+    }
+  }
+]'
+```
+
+- `wsToken` = como o agente **prova** que pode escutar aquele tenant (fica na URL
+  `/bridge/agent?token=<wsToken>`).
+- `config` = o que o adaptador precisa. Cada canal tem o seu shape.
+- **Boot-only:** mudou o JSON → reinicia o wa-gateway.
+
+## Adaptador Teams (src/bridge/channels/teams.ts)
+
+Implementa `ChannelAdapter` (`receive` / `send`). Diferenças do WhatsApp:
+
+- **receive:** o Teams manda "Activities" e **assina cada POST com um JWT** do Bot
+  Connector (emissor `https://api.botframework.com`). O adaptador:
+  1. Valida o JWT contra o JWKS `https://login.botframework.com/v1/keys`.
+  2. Confere `aud == appId` (senão é pra outro bot).
+  3. Parseia a Activity → extrai `text`, `serviceUrl`, `conversation.id`, `from`
+     (com `aadObjectId`, `name`).
+- **send:** pega um token AAD via `client_credentials` (appId + appPassword) e faz
+  `POST {serviceUrl}/v3/conversations/{id}/activities` com a resposta.
+- `verify: undefined` — Teams não faz handshake GET (o portal valida uma vez no POST).
+
+## Protocolo do WebSocket (bridge ↔ agente)
+
+O agente conecta em `/bridge/agent?token=<wsToken>` e troca JSON:
+
+| Direção | msg | conteúdo |
+|---------|-----|----------|
+| bridge → agente | `welcome` | `{ tenant }` — confirma conexão |
+| bridge → agente | `message` | `{ text, serviceUrl, conversation, from:{aadObjectId,name} }` |
+| agente → bridge | `send` | `{ serviceUrl, conversationId, text }` — resposta |
+| bridge → agente | `send_result` | `{ ok, error? }` |
+
+Isso é tudo que o agente precisa saber. O agente **não** fala com o Azure direto —
+só com o bridge. Quem posta no Teams é o wa-gateway (adapter.send).
+
+## Por que isolar por tenant
+
+Um wa-gateway atende N bots. Cada `wsToken` só enxerga o seu tenant. Um bot
+comprometido não lê mensagem de outro. WhatsApp real e Teams de teste convivem no
+mesmo processo sem se misturar.

--- a/docs/teams-bot/04-rodar-local.md
+++ b/docs/teams-bot/04-rodar-local.md
@@ -1,0 +1,75 @@
+# 04 — Rodar tudo local
+
+Provar o cano na máquina sem tocar em prd. Precisa de 3 processos + o zip instalado.
+
+## Pré-requisitos
+
+- Node 24 + pnpm. `pnpm install` na raiz do wa-gateway.
+- `better-sqlite3`/`bcrypt` são **nativos** — se der `bindings not found` no Node 24,
+  recompilar: `cd node_modules/better-sqlite3 && npx node-gyp rebuild` (lento).
+- `cloudflared` instalado (túnel rápido, sem conta).
+- Azure Bot já criado com canal Teams (doc 01) e endpoint apontando pro túnel.
+
+## .env local (exemplo)
+
+```ini
+NODE_ENV=DEVELOPMENT
+PORT=5001
+ADMIN_USER=admin
+ADMIN_PASSWORD=<qualquer>
+DB_PATH=/tmp
+WEBHOOK_BASE_URL=https://<tunel>.trycloudflare.com
+BRIDGE_TENANTS=[{"name":"teams-teste","channel":"teams","wsToken":"<wsToken>","config":{"appId":"62d5251f-...","appPassword":"<secret>","tenantId":"6fdfcb68-..."}}]
+```
+
+## Os 3 processos
+
+```bash
+# 1) wa-gateway (porta 5001)
+cd /home/weslan/projetos/wa-gateway
+./node_modules/.bin/tsx src/index.ts        # (script: /tmp/wa-run.sh)
+
+# 2) túnel público → aponta pro 5001
+cloudflared tunnel --url http://localhost:5001 --no-autoupdate
+#   copia a URL gerada (muda a cada start!) e:
+#   - põe no endpoint do Azure Bot: az bot update --endpoint https://<url>/ingress/teams-teste
+#   - põe em validDomains do manifest + WEBHOOK_BASE_URL
+
+# 3) agente de TESTE (shim) — conecta no bridge e responde
+cd /home/weslan/projetos/wa-gateway
+WS_TOKEN=<wsToken> node teams-shim.mjs
+```
+
+## Verificações rápidas
+
+```bash
+curl -s http://localhost:5001/bridge/status        # {"tenants_online":{"teams-teste":1}}  ← shim conectado
+curl -s -o /dev/null -w "%{http_code}\n" -X POST \
+  https://<tunel>.trycloudflare.com/ingress/teams-teste -d '{"ping":1}'   # 200 = túnel ok
+```
+
+- `tenants_online.teams-teste == 1` → o shim/agente está plugado.
+- Túnel 200 → o Azure consegue alcançar o wa-gateway.
+
+## O shim de teste (teams-shim.mjs)
+
+Programinha WebSocket (usa o `WebSocket` **nativo** do Node 24 — sem dependência)
+que:
+
+- conecta em `ws://localhost:5001/bridge/agent?token=<WS_TOKEN>`;
+- ao receber `message`, checa `from.aadObjectId` contra o ID do Weslan
+  (`5ef79d00-...`) — **bloqueia qualquer outro**;
+- responde `✅ recebido pelo agente (teste): "<texto>"`;
+- reconecta sozinho se cair.
+
+É só um **stub** pra provar o transporte. O agente real entra no doc
+[06](06-integrar-plataforma.md).
+
+## Pegadinhas
+
+- **URL do túnel muda a cada restart.** Reiniciou → atualiza endpoint do Azure +
+  validDomains + WEBHOOK_BASE_URL. (Some em prd.)
+- `import WebSocket from "ws"` quebra sob pnpm (ERR_MODULE_NOT_FOUND) → usar o
+  `WebSocket` **global** do Node 24.
+- Não confundir `pkill -f wa-gateway` com o control-plane local — nomes de processo
+  parecidos já derrubaram o CP por engano.

--- a/docs/teams-bot/05-controle-acesso.md
+++ b/docs/teams-bot/05-controle-acesso.md
@@ -1,0 +1,51 @@
+# 05 — Controle de acesso
+
+Regra: **fechado por padrão**. Bot novo não fala com ninguém até liberar. Duas
+camadas independentes:
+
+## Camada 1 — quem o bot RESPONDE (a que importa)
+
+Travada no **lado do agente**, pelo `aadObjectId` de cada pessoa (id estável do
+usuário no Entra, vem em toda mensagem do Teams em `from.aadObjectId`).
+
+- No shim de teste: constante `WESLAN = "5ef79d00-..."`; qualquer outro `from` é
+  ignorado (loga "BLOQUEADO").
+- Na plataforma: campo `teams.allowFrom` (lista de aadObjectIds) do agente. Vazio
+  = ninguém. Vira env `TEAMS_ALLOW_FROM` (lista separada por vírgula) que o agente
+  usa pra filtrar antes de processar.
+
+Essa é a trava **de verdade**: mesmo que o app esteja visível/instalado pra
+alguém, o bot só processa mensagem de quem está na lista.
+
+## Camada 2 — quem VÊ/INSTALA o app (cosmético/perímetro)
+
+Controlada no **Teams**:
+
+- **Sideload** (upload do zip): só instala na conta de quem subiu.
+- **Catálogo da org + política de permissão**: publica e libera o app só pra um
+  usuário/grupo. Exige Teams Admin. Ver [02](02-manifest-teams.md).
+
+Isso controla **visibilidade**, não resposta. Sozinha, não basta — a trava real é
+a camada 1.
+
+## Por que aadObjectId e não e-mail/nome
+
+- `aadObjectId` é **imutável** e único por pessoa no tenant. E-mail muda, nome
+  repete. (Mesma lição do CRM: resolver por id estável, nunca por e-mail.)
+- Pega o teu: manda uma mensagem pro bot e olha o `from.aadObjectId` no log do
+  wa-gateway/shim; ou no Entra (Usuários → o usuário → Object ID).
+
+## Grupos (futuro)
+
+Pra liberar por **grupo do Microsoft** (ex "Tecnologia") em vez de pessoa a
+pessoa: o agente resolve o grupo via Graph `checkMemberGroups` no `aadObjectId` do
+remetente e compara com uma allowlist de grupos. Mesmo padrão já usado no acordo
+comercial. Ainda não implementado no fluxo Teams — anotado no roadmap.
+
+## Resumo
+
+| Quero… | Onde |
+|--------|------|
+| Bot só responde pra mim | `teams.allowFrom` = [meu aadObjectId] (camada 1) |
+| App só aparece pra mim | sideload OU política Teams Admin (camada 2) |
+| Liberar um grupo inteiro | Graph checkMemberGroups (futuro) |

--- a/docs/teams-bot/06-integrar-plataforma.md
+++ b/docs/teams-bot/06-integrar-plataforma.md
@@ -1,0 +1,63 @@
+# 06 — Integrar na plataforma (trocar o shim pelo agente real)
+
+Objetivo: criar/gerenciar bot de Teams **pela interface** (agents.odd.com.br),
+como já se faz com Telegram — e o agente real (Claude) responder, não o shim.
+
+## O que JÁ foi feito (camada de config na UI) — 2026-07-28
+
+Control-plane (repo `agent-platform`), rodando em **modo teste local**:
+
+- **Modelo** (`core/types.go`): `AgentDef.Channel` ("telegram"|"teams", default
+  telegram) + struct `TeamsConfig` (`AppID`, `TenantID`, `WaGatewayURL`,
+  `WaTenant`, `AppPasswordRef`, `WsTokenRef`, `AllowFrom`). Validação exige os
+  campos quando `channel=teams`.
+- **specbuild**: quando `channel=teams`, injeta no container as envs
+  `CHANNEL=teams`, `TEAMS_APP_ID`, `TEAMS_TENANT_ID`, `WA_GATEWAY_URL`,
+  `WA_TENANT`, `TEAMS_ALLOW_FROM`, e resolve os 2 segredos
+  (`TEAMS_APP_PASSWORD`, `WA_WS_TOKEN`) do Secrets Manager. Tudo entra no
+  `hashDef` → trocar config recria o container (igual Telegram).
+- **API** (`teams_azure.go`): `GET /api/teams/bots` lista os bots reais do Azure
+  (ARM `botServices`) usando a identidade **manager** (client_credentials, escopo
+  ARM). Só leitura.
+- **UI** (`ui/index.html`): seletor "Canal" (Telegram/Teams). Em Teams, um
+  dropdown puxa os bots do Azure e preenche botId/tenant; mais os campos do
+  wa-gateway e o Acesso (aadObjectIds). Segredos vão como **ref** do cofre.
+
+Config: `AZURE_MANAGER_APP_ID/SECRET/TENANT/SUBSCRIPTION` (env do CP). Vazio →
+`/api/teams/bots` responde 503 e a UI cai pro preenchimento manual.
+
+## O que FALTA (o runtime do agente falar com a ponte)
+
+Hoje quem responde é o `teams-shim.mjs`. Falta o **agente de verdade** (container
+Claude Code da plataforma) conectar no bridge. Passos:
+
+1. **entrypoint.sh do agente**: se `CHANNEL=teams`, em vez de subir o canal
+   Telegram, subir um cliente que:
+   - conecta em `${WA_GATEWAY_URL}/bridge/agent?token=${WA_WS_TOKEN}`;
+   - ao receber `message`, filtra por `TEAMS_ALLOW_FROM`;
+   - passa o texto pro Claude Code (mesmo ponto de entrada que o canal Telegram
+     usa hoje) e devolve a resposta pelo `send` do WS.
+   Ou seja: portar a lógica do shim pra dentro do canal do agente — reaproveitando
+   o processamento que o plugin de Telegram já faz.
+2. **Provisionar o tenant no wa-gateway**: a plataforma precisa registrar o tenant
+   (`BRIDGE_TENANTS`) no wa-gateway com appId/appPassword/wsToken. Hoje é config
+   boot-only (JSON) → ou vira endpoint de admin no wa-gateway, ou um passo do
+   provisionamento.
+3. **Criar o bot no Azure automaticamente** (opcional, pra bot novo pela UI):
+   `az bot create` + canal Teams + endpoint apontando pro wa-gateway — via a
+   identidade manager (ARM). Publicar o app no Teams ainda esbarra no cargo Teams
+   Admin (ver [02](02-manifest-teams.md), 403).
+
+## Ordem recomendada
+
+1. ✅ Config na UI (feito, local).
+2. Portar o shim pro entrypoint (agente real responde). ← **próximo**
+3. Endpoint de registro de tenant no wa-gateway (sem reboot).
+4. Provisionamento Azure automático (bot novo pela UI).
+5. Publicação do app no Teams (resolver cargo admin).
+
+## Princípio
+
+O agente **nunca** abre porta nem fala com o Azure direto. Ele só disca pro bridge
+(igual Telegram long-poll disca pro Telegram). Todo o peso público/auth fica no
+wa-gateway. Isso mantém o modelo de segurança da plataforma intacto.

--- a/docs/teams-bot/07-virar-prd.md
+++ b/docs/teams-bot/07-virar-prd.md
@@ -1,0 +1,54 @@
+# 07 — Checklist pra virar produção
+
+Tudo hoje é **local**. Nada encosta no prd do wa-gateway (que recebe WhatsApp real)
+nem no prd da plataforma sem OK explícito. Este é o caminho pra promover.
+
+## Diferenças local → prd
+
+| Item | Local (teste) | Produção |
+|------|---------------|----------|
+| Ingress público | cloudflared quick tunnel (URL muda) | `https://wa-gateway.odd.com.br` (fixo, ECS) |
+| Segredos | cofre JSON local (`SECRETS_FILE`) | AWS Secrets Manager |
+| Endpoint do Azure Bot | URL do túnel | `https://wa-gateway.odd.com.br/ingress/<tenant>` |
+| Agente | shim (`teams-shim.mjs`) | container Claude da plataforma |
+| Tenant no wa-gateway | `.env` local | config do serviço prd (ver abaixo) |
+| CP | `cp-local` :8090 | control-plane em agents.odd.com.br |
+
+## Passos
+
+1. **Segredos → AWS SM.** `TEAMS_APP_PASSWORD` (client secret do bot) e o `wsToken`
+   do bridge viram secrets no SM. O def guarda só as **refs**
+   (`teams.appPasswordRef`, `teams.wsTokenRef`). Nunca no git.
+2. **Endpoint fixo do Azure Bot.** `az bot update --endpoint
+   https://wa-gateway.odd.com.br/ingress/<tenant>`. Some a dor de URL trocando.
+3. **validDomains do manifest** = `wa-gateway.odd.com.br`. Regerar o zip.
+4. **Registrar o tenant no wa-gateway prd.** Adicionar em `BRIDGE_TENANTS` (ou via
+   o endpoint de admin, quando existir — ver [06](06-integrar-plataforma.md)).
+   ⚠️ Mexer na config do wa-gateway prd = tocar no serviço que processa WhatsApp
+   real. **Só com OK explícito** e janela combinada. Preferir endpoint que adiciona
+   tenant sem reboot, pra não derrubar os canais de WhatsApp.
+5. **Agente real na plataforma.** entrypoint com `CHANNEL=teams` conectando no
+   bridge (etapa 2 do doc 06). Deploy pelo pipeline normal do agent-platform, nunca
+   docker manual.
+6. **Publicar o app no Teams.** Sideload não escala; publicar no catálogo da org
+   (Teams Admin) e liberar por política pra quem deve. Resolver o cargo Teams Admin
+   da identidade se for automatizar.
+7. **Acesso conferido.** `teams.allowFrom` com os aadObjectIds certos ANTES de
+   liberar o app. Fechado por padrão.
+
+## Guardrails (não esquecer)
+
+- ⛔ Não subir nada no wa-gateway prd por conta própria — ele recebe WhatsApp de
+  verdade. Config de tenant só com OK + janela.
+- ⛔ Segredos só no AWS SM em prd; cofre local é só teste.
+- ⛔ Deploy do agent-platform só pelo pipeline (release/webhook), nunca `docker
+  run`/`compose` manual no host.
+- Túnel cloudflared é **só teste** — não vai pra prd.
+
+## Pré-flight (antes de anunciar "tá no ar")
+
+- [ ] endpoint do Azure Bot = domínio prd, responde 200 no `/ingress/<tenant>`
+- [ ] tenant registrado no wa-gateway prd, `/bridge/status` mostra o agente online
+- [ ] `teams.allowFrom` conferido
+- [ ] app publicado/instalado só pra quem deve
+- [ ] mensagem de teste ponta a ponta respondida pelo agente REAL (não shim)

--- a/docs/teams-bot/08-glossario.md
+++ b/docs/teams-bot/08-glossario.md
@@ -1,0 +1,29 @@
+# 08 — Glossário
+
+Termos que aparecem no fluxo Teams + wa-gateway.
+
+| Termo | O que é |
+|-------|---------|
+| **Bot Framework** | Serviço da Microsoft que fica entre o Teams e o teu bot. Recebe a mensagem do usuário e faz um POST (webhook) pro teu endpoint, assinado com JWT. |
+| **Activity** | O JSON que o Bot Framework manda. Tem `type` (message, conversationUpdate…), `text`, `from`, `conversation`, `serviceUrl`. |
+| **serviceUrl** | URL de volta (dá o Bot Framework em cada Activity) pra onde o bot POSTa a resposta. Não é fixo — vem na mensagem. |
+| **conversation.id** | Id do chat específico. Usado pra postar a resposta no lugar certo. |
+| **aadObjectId** | Id imutável do usuário no Entra ID (Azure AD). Vem em `from.aadObjectId`. É por ele que travamos acesso (ver [05](05-controle-acesso.md)). |
+| **App ID / botId** | Id do app registration do bot no Entra. Mesmo valor no Azure Bot e no manifest. Identifica o bot. |
+| **client secret / appPassword** | Senha do app registration. Usada pra pegar token AAD e postar a resposta. Segredo. |
+| **JWT do Bot Connector** | Token que o Bot Framework põe no header `Authorization` de cada POST. Validamos contra o JWKS `login.botframework.com` pra garantir que a mensagem é legítima e é pro nosso bot (`aud == appId`). |
+| **JWKS** | Conjunto de chaves públicas (JSON Web Key Set) pra validar assinaturas JWT. |
+| **token AAD (client_credentials)** | Token que o bot pega (appId+appPassword) pra falar com a API do Bot Framework ao **responder**. Diferente do JWT que ele **recebe**. |
+| **Azure Bot (recurso)** | Recurso no Azure que amarra o App ID + o messaging endpoint + os canais (Teams, etc). |
+| **Canal (channel) no Azure Bot** | Liga o bot a uma plataforma (MsTeams, WebChat…). Sem o canal MsTeams, o Teams não fala com o bot. |
+| **manifest / app package** | O zip que torna o bot instalável/visível no Teams. Aponta pro App ID. Não cria bot. |
+| **sideload** | Subir o zip só pra tua conta ("Carregar aplicativo personalizado"). |
+| **validDomains** | Lista no manifest de domínios que o app pode acessar. Precisa conter o host do endpoint. |
+| **wa-gateway** | Nosso relay: recebe o webhook público, valida/traduz por adaptador, entrega pro agente pela ponte WS. Um por N bots. |
+| **tenant (no wa-gateway)** | Uma "linha" de config no wa-gateway = um bot/canal. Isola credenciais e o `wsToken`. Não confundir com tenant do Azure AD. |
+| **tenant (Azure AD / Entra)** | A organização no Entra (Limppano = `6fdfcb68-...`). |
+| **bridge / ponte** | O WebSocket `/bridge/agent?token=...` por onde o agente disca pra fora e recebe/manda mensagens. |
+| **wsToken** | Segredo que o agente usa pra provar que pode escutar um tenant no bridge. |
+| **shim** | Programinha de teste (`teams-shim.mjs`) que finge ser o agente pra provar o cano. Substituído pelo agente real depois. |
+| **identidade manager** | App de provisionamento (`agent-platform-manager`) que a plataforma usa pra falar com Azure (listar/criar bots). App-only, sem cargo Teams Admin (por isso não publica app no catálogo). |
+| **cloudflared quick tunnel** | Túnel público temporário (sem conta) pra expor o wa-gateway local. Só teste; URL muda a cada start. |

--- a/docs/teams-bot/09-go-live.md
+++ b/docs/teams-bot/09-go-live.md
@@ -1,0 +1,118 @@
+# 09 — Go-Live: bots Teams na plataforma (ecommerce primeiro)
+
+Mapa do que falta pra sair do teste local e colocar em produção um bot Teams —
+começando pelo **ecommerce**, que é **grupo** (várias pessoas, mesmo chat).
+
+## 1. O que já temos (local/teste) ✅
+
+- Interface (control-plane): seletor de canal Telegram/Teams + dropdown que lista
+  os bots reais do Azure (identidade manager).
+- Sidecar do agente (`teams-agent.mjs`, na imagem): conecta na ponte, roda o Claude
+  real por mensagem, sabe com quem fala (nome + aadObjectId), acesso travado
+  (`allowFrom`), envia arquivo (via link `/files`).
+- wa-gateway (branch `feat/meta-cloud-relay`): ponte + adaptador Teams (valida JWT,
+  responde no serviceUrl) + servir arquivo.
+- Bot de teste `agent-teams-teste` funcionando 1:1 só com o Weslan.
+
+Tudo isso é **comportamento padrão da imagem/sidecar** → todo bot Teams novo herda.
+Só os identificadores (appId, tenant, wsToken, acesso) variam por bot, na interface.
+
+## 2. Gaps pra produção (checklist)
+
+### Infra / deploy
+- [ ] **wa-gateway prod**: registrar o tenant do bot **sem reboot**. Hoje
+  `BRIDGE_TENANTS` é config boot-only; em prd o serviço processa WhatsApp real —
+  não pode reiniciar à toa. → criar endpoint admin de "registrar tenant".
+- [ ] **URL pública fixa**: trocar o túnel cloudflared (teste) por
+  `https://wa-gateway.odd.com.br`. Atualizar o **endpoint do Azure Bot** e o
+  `validDomains` do manifest.
+- [ ] **Secrets → AWS Secrets Manager**: `appPassword` do bot + `wsToken` da ponte.
+  O def guarda só as refs. Nada no git/cofre local.
+- [ ] **Imagem do agente com sidecar Teams em prd**: deploy pela pipeline do
+  agent-platform (o sidecar já está na imagem; falta buildar/deployar em prd).
+- [ ] **Onde roda o agente ecommerce**: server .89 (agents-host) ou outro. Definir.
+- [ ] **Creds Azure manager no CP de prd** (pra o dropdown de bots): via env seguro
+  (não commitar).
+- [ ] **FILES_BASE_URL** = `https://wa-gateway.odd.com.br` em prd.
+
+### Segurança
+- [ ] **Link de arquivo com token** (hoje o `/files/:id` é aberto por 1h). Em prd:
+  assinar o link (token curto) pra não vazar arquivo por URL adivinhável.
+- [ ] **Acesso fechado por padrão**: `allowFrom` (pessoas) ou grupo AAD conferido
+  ANTES de publicar.
+- [ ] Revisar o que o agente pode fazer (tools/repos) — ecommerce mexe em quê?
+
+### Bot ecommerce (Azure + Teams)
+- [ ] Criar **Azure Bot** `agent-ecommerce` + canal Teams + endpoint prd.
+- [ ] **Manifest** do app ecommerce com os **scopes certos** (grupo → `team` e/ou
+  `groupChat`, não só `personal`).
+- [ ] **Publicar** no Teams: catálogo da org (Teams Admin) restrito ao grupo do
+  ecommerce, OU sideload. (Ver [02](02-manifest-teams.md).)
+
+## 3. Migração local → prd (ordem)
+
+1. Secrets pro AWS SM (appPassword, wsToken) → refs no def.
+2. wa-gateway prd: endpoint de registrar tenant + registrar o tenant do ecommerce.
+3. Azure Bot ecommerce com endpoint `wa-gateway.odd.com.br/ingress/<tenant>`.
+4. Deploy da imagem do agente (com sidecar) pela pipeline.
+5. Criar o agente `ecommerce` na interface (channel=teams, os campos + acesso).
+6. Manifest + publicar o app restrito ao grupo.
+7. Teste E2E com uma pessoa do grupo → depois liberar o grupo.
+
+## 4. "Pegar todo o contexto que temos"
+
+O bot de teste é **genérico** — não tem contexto de negócio. "Contexto" de um bot
+vem de 3 lugares (tudo configurável pela interface / def, sem código):
+
+- **Persona** (`CLAUDE.md` do agente): quem ele é, o que faz, tom, regras. É aqui
+  que entra o conhecimento do ecommerce.
+- **Repos** clonados no boot: o código/projeto que o agente enxerga (ex: repo do
+  ecommerce).
+- **Integrações MCP** (ex: `mcp-tools`/memória, um Postgres, uma API): dão dados e
+  memória. Token próprio de `mcp-tools` = memória escopada do bot.
+
+Pro ecommerce: definir a **persona**, os **repos** e as **integrações** que ele
+precisa. Isso NÃO se migra do bot de teste (que é vazio) — se **monta** pro
+ecommerce. O que se reaproveita é a **plataforma** (imagem, sidecar, ponte).
+
+## 5. Grupo: várias pessoas no mesmo chat
+
+O ecommerce é um **grupo**. Hoje o sidecar assume **1:1**. O que muda:
+
+| Tema | 1:1 (hoje) | Grupo (ecommerce) |
+|------|------------|-------------------|
+| Quando responde | toda mensagem | **só quando @mencionado** (senão responde tudo e vira spam) |
+| Identidade | injeta o nome 1x na 1ª msg | **por mensagem** — em grupo cada msg é de uma pessoa diferente |
+| Sessão/contexto | 1 sessão por conversa | 1 sessão **compartilhada** do grupo (todos veem o mesmo fio) — a decidir |
+| Acesso | `allowFrom` (pessoa) | por **grupo AAD** (checkMemberGroups) ou liberar a conversa |
+| Manifest | scope `personal` | scope `team`/`groupChat` |
+
+Mudanças no sidecar/adaptador pra grupo:
+- **Detecção de @menção**: o Teams manda as menções em `activity.entities`; o bot
+  tira o próprio @nome do texto e só age se foi mencionado.
+- **Identidade por mensagem**: passar `from.name` de CADA mensagem pro Claude (não
+  só na 1ª), pra ele saber quem falou o quê no grupo.
+- **Acesso por grupo**: liberar quem é do grupo AAD do ecommerce (Graph
+  `checkMemberGroups`) em vez de listar pessoa a pessoa.
+
+## 6. Tópicos pra decidir (traz pra conversa)
+
+1. **Grupo — sessão compartilhada ou por pessoa?** Um fio só que todos veem
+   (assistente do grupo) vs cada um com seu contexto. (Recomendo compartilhada.)
+2. **Acesso do ecommerce**: qual grupo AAD / quais pessoas? Fechado por padrão.
+3. **Publicação**: catálogo da org restrito (precisa Teams Admin) vs sideload por
+   pessoa.
+4. **Arquivo**: link com token (rápido) — ok pra prd? Ou investir no anexo nativo
+   (mais frágil por client)?
+5. **Onde roda o agente ecommerce** (server .89 ou outro) + recursos.
+6. **Persona/escopo do bot ecommerce**: o que ele faz, quais repos e integrações
+   (tools/dados/memória) ele precisa? É o que dá "contexto" a ele.
+7. **wa-gateway prd**: topa a gente adicionar o endpoint de registrar tenant (pra
+   não reiniciar o serviço que roda o WhatsApp real)?
+
+## 7. Guardrails (não esquecer)
+
+- ⛔ Nada sobe no wa-gateway prd sem OK + janela (ele recebe WhatsApp real).
+- ⛔ Secrets só no AWS SM em prd.
+- ⛔ Deploy só pela pipeline do agent-platform.
+- Acesso fechado por padrão; conferir antes de publicar.

--- a/docs/teams-bot/README.md
+++ b/docs/teams-bot/README.md
@@ -1,0 +1,37 @@
+# Teams Bot via wa-gateway
+
+Como conectar um **bot do Microsoft Teams** a um agente da plataforma usando o
+**wa-gateway** como ponte (mesmo padrão que já usamos pro WhatsApp/Meta Cloud).
+
+Objetivo final: criar/gerenciar bots de Teams **pela interface** (agents.odd.com.br),
+com controle de acesso (quem pode falar, quais grupos), do mesmo jeito que os bots
+de Telegram — sem tocar em Azure na mão a cada bot novo.
+
+## Estado atual (2026-07-28)
+
+Fase de **prova de conceito local**: um bot de teste (`agent-teams-teste`) roda
+100% na máquina do Weslan (wa-gateway local + túnel), com acesso travado só nele.
+Ainda usando um **shim de teste** no lugar do agente real — o próximo passo é
+plugar o agente de verdade e expor tudo na interface.
+
+## Índice
+
+| Doc | Assunto |
+|-----|---------|
+| [00-visao-geral.md](00-visao-geral.md) | Arquitetura ponta a ponta, o "cano" |
+| [01-azure-setup.md](01-azure-setup.md) | O que se cria no Azure (app, bot, canal) |
+| [02-manifest-teams.md](02-manifest-teams.md) | Pacote do app Teams (manifest + zip), instalar |
+| [03-wa-gateway-bridge.md](03-wa-gateway-bridge.md) | Como o wa-gateway faz a ponte (ingress → bridge) |
+| [04-rodar-local.md](04-rodar-local.md) | Subir tudo local (wa-gateway, túnel, shim) |
+| [05-controle-acesso.md](05-controle-acesso.md) | Travar acesso a 1 pessoa / grupo |
+| [06-integrar-plataforma.md](06-integrar-plataforma.md) | Trocar o shim pelo agente real na interface |
+| [07-virar-prd.md](07-virar-prd.md) | Checklist pra ir pra produção |
+| [08-glossario.md](08-glossario.md) | Termos (Bot Framework, serviceUrl, aadObjectId…) |
+
+## Regra de ouro
+
+- **Local primeiro.** Nada disso encosta no prd do wa-gateway (que recebe os
+  WhatsApp de verdade) nem na plataforma de prd sem OK explícito.
+- **Acesso fechado por padrão.** Bot novo nasce restrito; libera-se depois.
+- Segredos (bot password, tokens) vão pro **AWS Secrets Manager** quando virar
+  prd — nunca no git.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wa-gateway",
   "version": "4.3.2",
+  "packageManager": "pnpm@11.1.3",
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "4.3.2",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "start": "tsx src/index.ts"
+    "start": "tsx src/index.ts",
+    "test": "tsx --test src/**/*.test.ts"
   },
   "author": {
     "name": "mimamch",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.1",
-    "@types/qrcode": "^1.5.5"
+    "@types/qrcode": "^1.5.5",
+    "@types/ws": "^8.5.12"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@types/qrcode':
         specifier: ^1.5.5
         version: 1.5.5
+      '@types/ws':
+        specifier: ^8.5.12
+        version: 8.18.1
 
 packages:
 
@@ -363,6 +366,9 @@ packages:
 
   '@types/qrcode@1.5.5':
     resolution: {integrity: sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.38.0':
     resolution: {integrity: sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==}
@@ -1058,7 +1064,7 @@ packages:
     engines: {node: '>= 0.8.0'}
 
   libsignal@https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
-    resolution: {gitHosted: true, integrity: sha512-KmRMuAYSfd4upRD0xOgKbURxRXNE8X8NtgmkUOJFXOn9ESSCXguIZ7PJu8OBJIr7KGww41Vf/Pbgko+PgWQ55g==, tarball: https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/WhiskeySockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7}
     version: 6.0.0
 
   link-preview-js@3.0.14:
@@ -1842,6 +1848,10 @@ snapshots:
   '@types/qrcode-terminal@0.12.2': {}
 
   '@types/qrcode@1.5.5':
+    dependencies:
+      '@types/node': 22.10.1
+
+  '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.10.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,18 @@
+# Pacotes autorizados a rodar script de build (compilação nativa).
+#
+# `allowBuilds` é a chave do pnpm 10+; `onlyBuiltDependencies` é a antiga e fica
+# pra quem rodar com pnpm 9. Sem a nova, o pnpm 11 ABORTA o install com
+# ERR_PNPM_IGNORED_BUILDS em vez de só avisar — o que quebra o build da imagem,
+# não só o CI.
+#
+# Todos aqui precisam compilar de verdade: bcrypt e better-sqlite3 são nativos,
+# esbuild baixa binário, protobufjs e baileys têm postinstall.
+allowBuilds:
+  '@whiskeysockets/baileys': true
+  bcrypt: true
+  better-sqlite3: true
+  esbuild: true
+  protobufjs: true
 onlyBuiltDependencies:
   - '@whiskeysockets/baileys'
   - bcrypt

--- a/src/bridge/channels/index.ts
+++ b/src/bridge/channels/index.ts
@@ -9,7 +9,10 @@ const adapters: Record<string, ChannelAdapter> = {
   teams: teamsAdapter,
 };
 
+// Object.hasOwn: o `channel` vem do def do tenant, que em runtime vem do corpo
+// de uma requisição. `adapters["__proto__"]` resolveria pela cadeia de protótipo
+// e devolveria algo que não é adapter. (CWE-1321)
 export function adapterFor(channel: string | undefined): ChannelAdapter | null {
-  if (!channel) return null;
-  return adapters[channel] || null;
+  if (!channel || !Object.hasOwn(adapters, channel)) return null;
+  return adapters[channel] ?? null;
 }

--- a/src/bridge/channels/teams.ts
+++ b/src/bridge/channels/teams.ts
@@ -11,6 +11,7 @@
 // receive: valida JWT (aud == appId), extrai texto + serviceUrl + conversation.
 // send: token AAD (client_credentials) → POST {serviceUrl}/v3/conversations/{id}/activities
 
+import { randomUUID } from "node:crypto";
 import axios from "axios";
 import { createRemoteJWKSet, jwtVerify } from "jose";
 import type { TenantDef } from "../config";
@@ -18,9 +19,23 @@ import type { ChannelAdapter, IngestResult, SendResult } from "./types";
 
 // JWKS do Bot Connector (chaves públicas pra validar o JWT que o Teams manda).
 // OpenID metadata: https://login.botframework.com/v1/.well-known/openidconfiguration
+// → jwks_uri = /v1/.well-known/keys (o /v1/keys dá 404 e derruba a validação).
 const BOTFRAMEWORK_JWKS = createRemoteJWKSet(
-  new URL("https://login.botframework.com/v1/keys"),
+  new URL("https://login.botframework.com/v1/.well-known/keys"),
 );
+
+// Envio de arquivo NATIVO no Teams = "file consent card" (2 passos): o bot manda
+// um card pedindo permissão; ao aceitar, o Teams devolve um invoke com uma
+// uploadUrl (OneDrive pré-autenticada do usuário — seguro, não é link público) e
+// o bot dá PUT dos bytes. Guardamos os bytes entre os passos, por um id no card.
+// Obs: renderiza no Teams desktop/web; o mobile não suporta esse card (limitação MS).
+type PendingFile = {
+  bytes: Buffer;
+  name: string;
+  serviceUrl: string;
+  conversationId: string;
+};
+const pendingFiles = new Map<string, PendingFile>();
 
 export const teamsAdapter: ChannelAdapter = {
   name: "teams",
@@ -58,6 +73,21 @@ export const teamsAdapter: ChannelAdapter = {
     } catch {
       return null;
     }
+
+    // invoke de consentimento de arquivo: o usuário aceitou/recusou o card. Não vai
+    // pra ponte — resolvemos aqui (upload dos bytes na uploadUrl do OneDrive). O
+    // Teams EXIGE um InvokeResponse ({status:200}) na resposta HTTP, senão mostra
+    // "não há suporte para esta ação de cartão".
+    if (activity?.type === "invoke" && activity?.name === "fileConsent/invoke") {
+      try {
+        await handleFileConsent(activity, tenant);
+        return { response: { status: 200, json: { status: 200 } } };
+      } catch (e: any) {
+        console.error("[teams] file consent:", e?.message || e);
+        return { response: { status: 200, json: { status: 502 } } };
+      }
+    }
+
     // só interessa mensagem de texto
     if (activity?.type !== "message") return null;
 
@@ -75,16 +105,57 @@ export const teamsAdapter: ChannelAdapter = {
     };
   },
 
-  // Envia texto de volta pra conversa do Teams.
-  // payload = { serviceUrl, conversationId, text }
+  // Envio (agente → Teams). Dois modos:
+  //   texto:   { serviceUrl, conversationId, text }
+  //   arquivo: { serviceUrl, conversationId, file: { name, contentBase64, description? } }
+  // Arquivo dispara o "file consent card"; o upload real acontece no invoke de aceite.
   async send(payload: Record<string, any>, tenant: TenantDef): Promise<SendResult> {
-    const { serviceUrl, conversationId, text } = payload;
+    const { serviceUrl, conversationId, text, file } = payload;
+
+    if (file && file.contentBase64) {
+      if (!serviceUrl || !conversationId || !file.name) {
+        return { ok: false, error: "serviceUrl, conversationId e file.name obrigatórios" };
+      }
+      // Arquivo nativo: manda o file consent card. O upload real acontece quando o
+      // usuário aceita (invoke → handleFileConsent). Guarda os bytes até lá.
+      try {
+        const bytes = Buffer.from(file.contentBase64, "base64");
+        const id = randomUUID();
+        pendingFiles.set(id, { bytes, name: file.name, serviceUrl, conversationId });
+        setTimeout(() => pendingFiles.delete(id), 10 * 60 * 1000).unref?.();
+
+        const accessToken = await getBotToken(tenant);
+        const uri = activitiesUri(serviceUrl, conversationId);
+        const resp = await axios.post(
+          uri,
+          {
+            type: "message",
+            attachments: [{
+              contentType: "application/vnd.microsoft.teams.card.file.consent",
+              name: file.name,
+              content: {
+                description: file.description || `Arquivo: ${file.name}`,
+                sizeInBytes: bytes.length,
+                acceptContext: { id },
+                declineContext: { id },
+              },
+            }],
+          },
+          { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" } },
+        );
+        return { ok: true, id: resp.data?.id ?? null };
+      } catch (error: any) {
+        const detail = error?.response?.data?.error?.message || error?.message || "erro desconhecido";
+        return { ok: false, error: detail };
+      }
+    }
+
     if (!serviceUrl || !conversationId || !text) {
-      return { ok: false, error: "serviceUrl, conversationId e text obrigatórios" };
+      return { ok: false, error: "serviceUrl, conversationId e text (ou file) obrigatórios" };
     }
     try {
       const accessToken = await getBotToken(tenant);
-      const uri = `${String(serviceUrl).replace(/\/$/, "")}/v3/conversations/${encodeURIComponent(conversationId)}/activities`;
+      const uri = activitiesUri(serviceUrl, conversationId);
       const resp = await axios.post(
         uri,
         { type: "message", text },
@@ -97,6 +168,55 @@ export const teamsAdapter: ChannelAdapter = {
     }
   },
 };
+
+// activitiesUri monta a URL pra postar uma activity numa conversa.
+function activitiesUri(serviceUrl: string, conversationId: string): string {
+  return `${String(serviceUrl).replace(/\/$/, "")}/v3/conversations/${encodeURIComponent(conversationId)}/activities`;
+}
+
+// handleFileConsent trata o invoke de aceite/recusa do card de arquivo. No aceite,
+// dá PUT dos bytes na uploadUrl (OneDrive do usuário, já autenticada) e manda um
+// "file.info" card, que faz o arquivo aparecer no chat pra download.
+async function handleFileConsent(activity: any, tenant: TenantDef): Promise<void> {
+  const v = activity?.value || {};
+  const id = v?.context?.id;
+  const pending = id ? pendingFiles.get(id) : undefined;
+
+  if (v?.action !== "accept" || !pending) {
+    if (id) pendingFiles.delete(id); // recusou ou expirou — limpa
+    return;
+  }
+  pendingFiles.delete(id);
+
+  const up = v.uploadInfo || {};
+  if (!up.uploadUrl) throw new Error("invoke sem uploadInfo.uploadUrl");
+
+  // Upload dos bytes pro OneDrive do usuário (URL já autenticada; sem Bearer).
+  await axios.put(up.uploadUrl, pending.bytes, {
+    headers: {
+      "Content-Length": String(pending.bytes.length),
+      "Content-Range": `bytes 0-${pending.bytes.length - 1}/${pending.bytes.length}`,
+    },
+    maxBodyLength: Infinity,
+    maxContentLength: Infinity,
+  });
+
+  // file.info card → o arquivo aparece no chat.
+  const accessToken = await getBotToken(tenant);
+  await axios.post(
+    activitiesUri(pending.serviceUrl, pending.conversationId),
+    {
+      type: "message",
+      attachments: [{
+        contentType: "application/vnd.microsoft.teams.card.file.info",
+        contentUrl: up.contentUrl,
+        name: up.name || pending.name,
+        content: { uniqueId: up.uniqueId, fileType: up.fileType },
+      }],
+    },
+    { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" } },
+  );
+}
 
 // Token AAD do App do bot (client_credentials). Single-tenant usa o tenantId;
 // multi-tenant usaria "botframework.com". Cache simples em memória por appId.

--- a/src/bridge/channels/types.ts
+++ b/src/bridge/channels/types.ts
@@ -14,6 +14,10 @@ export interface VerifyResult {
 export interface IngestResult {
   // objeto a empurrar pro agente pela ponte (ou undefined pra ignorar).
   push?: unknown;
+  // resposta HTTP que a rota /ingress deve devolver ao canal (ex: Teams exige
+  // um InvokeResponse pro fileConsent/invoke, senão mostra "ação não suportada").
+  // Se presente, a rota devolve isso em vez do "ok" padrão.
+  response?: { status: number; json?: unknown; body?: string };
 }
 
 export interface SendResult {

--- a/src/bridge/channels/whatsapp.ts
+++ b/src/bridge/channels/whatsapp.ts
@@ -39,19 +39,44 @@ export const whatsappAdapter: ChannelAdapter = {
     return { push: { source: "whatsapp", entry: payload.entry ?? [] } };
   },
 
+  // Envia texto OU botões interativos. payload:
+  //   { to, text }                                  → mensagem de texto
+  //   { to, interactive: { body, buttons:[{id,title}] } } → botões clicáveis (máx 3)
   async send(payload: Record<string, any>, tenant: TenantDef): Promise<SendResult> {
-    const { to, text } = payload;
+    const { to, text, interactive } = payload;
     const { phoneNumberId, metaToken } = tenant.config;
     const apiVersion = tenant.config.apiVersion || "v20.0";
     if (!metaToken || !phoneNumberId) return { ok: false, error: "tenant whatsapp sem metaToken/phoneNumberId" };
-    if (!to || !text) return { ok: false, error: "to e text obrigatórios" };
+    if (!to) return { ok: false, error: "to obrigatório" };
+
+    let body: Record<string, any>;
+    if (interactive && Array.isArray(interactive.buttons) && interactive.buttons.length) {
+      body = {
+        messaging_product: "whatsapp",
+        to,
+        type: "interactive",
+        interactive: {
+          type: "button",
+          body: { text: String(interactive.body || "").slice(0, 1024) },
+          action: {
+            buttons: interactive.buttons.slice(0, 3).map((b: any) => ({
+              type: "reply",
+              reply: { id: String(b.id).slice(0, 256), title: String(b.title).slice(0, 20) },
+            })),
+          },
+        },
+      };
+    } else if (text) {
+      body = { messaging_product: "whatsapp", to, type: "text", text: { body: text, preview_url: false } };
+    } else {
+      return { ok: false, error: "text ou interactive obrigatório" };
+    }
+
     try {
       const uri = `https://graph.facebook.com/${apiVersion}/${phoneNumberId}/messages`;
-      const resp = await axios.post(
-        uri,
-        { messaging_product: "whatsapp", to, type: "text", text: { body: text, preview_url: false } },
-        { headers: { Authorization: `Bearer ${metaToken}`, "Content-Type": "application/json" } },
-      );
+      const resp = await axios.post(uri, body, {
+        headers: { Authorization: `Bearer ${metaToken}`, "Content-Type": "application/json" },
+      });
       return { ok: true, id: resp.data?.messages?.[0]?.id ?? null };
     } catch (error: any) {
       const detail = error?.response?.data?.error?.message || error?.message || "erro desconhecido";

--- a/src/bridge/config.test.ts
+++ b/src/bridge/config.test.ts
@@ -1,0 +1,168 @@
+// config.test.ts — trava o comportamento crítico do registro de tenant em
+// runtime. Rodar: pnpm test
+//
+// O que está sendo protegido aqui é sobretudo a PRECEDÊNCIA do env. A rota de
+// registro é autenticada por um token único; se ela pudesse regravar o tenant
+// "sac", um bot novo passaria a receber (e responder) o WhatsApp de produção do
+// SAC. Nenhum desses testes é sobre estética de API.
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TOK_SAC = "tok-sac-de-producao-nao-toque";
+const TOK_BOT = "tok-bot-runtime-1234567890";
+const TOK_BOT2 = "tok-bot-runtime-rotacionado-99";
+
+let dir: string;
+let cfg: typeof import("./config");
+let hub: typeof import("./hub");
+
+before(async () => {
+  dir = mkdtempSync(join(tmpdir(), "wagw-test-"));
+  process.env.DB_PATH = join(dir, "test.db");
+  process.env.ADMIN_USER = "t";
+  process.env.ADMIN_PASSWORD = "t";
+  process.env.BRIDGE_TENANTS = JSON.stringify({
+    sac: {
+      wsToken: TOK_SAC,
+      channel: "whatsapp",
+      config: { verifyToken: "v", phoneNumberId: "1", metaToken: "m" },
+    },
+  });
+  // import dinâmico: o módulo lê o env no load, então o env tem que estar pronto.
+  cfg = await import("./config");
+  hub = await import("./hub");
+});
+
+after(() => rmSync(dir, { recursive: true, force: true }));
+
+const teams = { appId: "a", appPassword: "p", tenantId: "t" };
+
+test("tenant do env é encontrado e marcado como origem env", () => {
+  assert.equal(cfg.tenant("sac")?.channel, "whatsapp");
+  assert.equal(cfg.origemDoTenant("sac"), "env");
+});
+
+test("registra tenant de runtime e ele passa a existir na hora, sem restart", () => {
+  const r = cfg.registrarTenant("bot-diretoria", "teams", TOK_BOT, teams);
+  assert.equal(r.ok, true);
+  assert.equal(r.status, 201);
+  assert.equal(cfg.tenant("bot-diretoria")?.channel, "teams");
+  assert.equal(cfg.tenantByWsToken(TOK_BOT), "bot-diretoria");
+  assert.equal(cfg.origemDoTenant("bot-diretoria"), "runtime");
+});
+
+test("registrar de novo é idempotente (retry da plataforma não quebra)", () => {
+  const r = cfg.registrarTenant("bot-diretoria", "teams", TOK_BOT, teams);
+  assert.equal(r.ok, true);
+  assert.equal(r.status, 200);
+  assert.equal(r.criado, false);
+});
+
+test("NÃO deixa runtime sobrescrever tenant do env", () => {
+  const r = cfg.registrarTenant("sac", "teams", "tok-invasor-1234567890", teams);
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 409);
+  // e o sac segue intacto
+  assert.equal(cfg.tenant("sac")?.channel, "whatsapp");
+  assert.equal(cfg.tenantByWsToken(TOK_SAC), "sac");
+});
+
+test("NÃO deixa remover tenant do env", () => {
+  const r = cfg.removerTenant("sac");
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 409);
+  assert.equal(cfg.tenant("sac")?.channel, "whatsapp");
+});
+
+test("NÃO deixa roubar o wsToken de um tenant do env", () => {
+  const r = cfg.registrarTenant("bot-esperto", "teams", TOK_SAC, teams);
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 409);
+  // o token continua resolvendo pro sac, não pro bot
+  assert.equal(cfg.tenantByWsToken(TOK_SAC), "sac");
+});
+
+test("NÃO deixa dois tenants de runtime com o mesmo wsToken", () => {
+  const r = cfg.registrarTenant("bot-outro", "teams", TOK_BOT, teams);
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 409);
+});
+
+test("recusa config de canal incompleta", () => {
+  const r = cfg.registrarTenant("bot-torto", "teams", "tok-bot-torto-1234567890", { appId: "a" });
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 400);
+  assert.match(r.erro!, /appPassword/);
+  assert.equal(cfg.tenant("bot-torto"), null);
+});
+
+test("recusa canal desconhecido", () => {
+  const r = cfg.registrarTenant("bot-x", "telepatia", "tok-bot-x-1234567890abc", {});
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 400);
+});
+
+test("recusa nome que viraria rota estranha", () => {
+  for (const nome of ["../etc", "com barra/", "MAIUSCULA", "a", ""]) {
+    const r = cfg.registrarTenant(nome, "teams", "tok-nome-ruim-1234567890", teams);
+    assert.equal(r.ok, false, `aceitou nome inválido: ${JSON.stringify(nome)}`);
+    assert.equal(r.status, 400);
+  }
+});
+
+test("recusa wsToken curto", () => {
+  const r = cfg.registrarTenant("bot-curto", "teams", "curto", teams);
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 400);
+});
+
+test("trocar o wsToken derruba a conexão autenticada com o antigo", () => {
+  // Socket de mentira: só precisa de close() e readyState pro hub.
+  let fechado = false;
+  const fake: any = { readyState: 1, close: () => (fechado = true), terminate: () => (fechado = true), send: () => {} };
+  hub.bridgeHub.registrar("bot-diretoria", fake);
+  assert.equal(hub.bridgeHub.status()["bot-diretoria"], 1);
+
+  const r = cfg.registrarTenant("bot-diretoria", "teams", TOK_BOT2, teams);
+  assert.equal(r.ok, true);
+  assert.equal(fechado, true, "conexão com o token antigo continuou aberta");
+  assert.equal(hub.bridgeHub.status()["bot-diretoria"], undefined);
+  // token antigo não autentica mais; o novo sim
+  assert.equal(cfg.tenantByWsToken(TOK_BOT), null);
+  assert.equal(cfg.tenantByWsToken(TOK_BOT2), "bot-diretoria");
+});
+
+test("remover derruba a ponte e o tenant deixa de existir", () => {
+  let fechado = false;
+  const fake: any = { readyState: 1, close: () => (fechado = true), terminate: () => {}, send: () => {} };
+  hub.bridgeHub.registrar("bot-diretoria", fake);
+
+  const r = cfg.removerTenant("bot-diretoria");
+  assert.equal(r.ok, true);
+  assert.equal(fechado, true, "ponte seguiu aberta depois de remover o tenant");
+  assert.equal(cfg.tenant("bot-diretoria"), null);
+  assert.equal(cfg.tenantByWsToken(TOK_BOT2), null);
+});
+
+test("remover tenant inexistente é 404", () => {
+  assert.equal(cfg.removerTenant("nunca-existiu").status, 404);
+});
+
+test("sobrevive a restart: recarrega do banco", () => {
+  cfg.registrarTenant("bot-persistente", "teams", "tok-persistente-1234567890", teams);
+  cfg._recarregar(); // simula o boot lendo a tabela
+  assert.equal(cfg.tenant("bot-persistente")?.channel, "teams");
+  assert.equal(cfg.tenantByWsToken("tok-persistente-1234567890"), "bot-persistente");
+});
+
+test("listagem não vaza wsToken nem segredo de canal", () => {
+  const serial = JSON.stringify(cfg.listarTenants());
+  assert.ok(!serial.includes("tok-"), "wsToken apareceu na listagem");
+  assert.ok(!serial.includes("appPassword"), "segredo de canal apareceu na listagem");
+  assert.ok(serial.includes("bot-persistente"));
+  assert.ok(serial.includes("sac"));
+});

--- a/src/bridge/config.test.ts
+++ b/src/bridge/config.test.ts
@@ -120,6 +120,45 @@ test("recusa wsToken curto", () => {
   assert.equal(r.status, 400);
 });
 
+test("NÃO deixa OUTRO bot ocupar um nome de tenant que já tem dono", () => {
+  // Simula a conexão viva do bot que já é dono do nome.
+  let fechado = false;
+  const fake: any = { readyState: 1, close: () => (fechado = true), terminate: () => {}, send: () => {} };
+  hub.bridgeHub.registrar("bot-diretoria", fake);
+
+  // Outro appId = outro bot. Antes isto sobrescrevia as credenciais do dono e
+  // derrubava a ponte dele, e a criação reportava sucesso.
+  const r = cfg.registrarTenant("bot-diretoria", "teams", "tok-do-invasor-1234567890", {
+    appId: "OUTRO-APP",
+    appPassword: "p",
+    tenantId: "t",
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 409);
+  assert.match(r.erro!, /já pertence a outro appId/);
+  assert.equal(fechado, false, "derrubou a ponte do dono legítimo");
+  // o dono segue com o token dele funcionando
+  assert.equal(cfg.tenantByWsToken(TOK_BOT), "bot-diretoria");
+  assert.equal(cfg.tenantByWsToken("tok-do-invasor-1234567890"), null);
+  hub.bridgeHub.remover("bot-diretoria", fake);
+});
+
+test("MESMO bot (mesmo appId) pode reescrever — é retry/rotação", () => {
+  const r = cfg.registrarTenant("bot-diretoria", "teams", TOK_BOT, { ...teams, appPassword: "senha-rotacionada" });
+  assert.equal(r.ok, true);
+  assert.equal(cfg.tenant("bot-diretoria")?.config.appPassword, "senha-rotacionada");
+});
+
+test("NÃO deixa trocar o canal de um tenant existente", () => {
+  const r = cfg.registrarTenant("bot-diretoria", "whatsapp", TOK_BOT, {
+    verifyToken: "v",
+    phoneNumberId: "1",
+    metaToken: "m",
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 409);
+});
+
 test("trocar o wsToken derruba a conexão autenticada com o antigo", () => {
   // Socket de mentira: só precisa de close() e readyState pro hub.
   let fechado = false;
@@ -157,6 +196,45 @@ test("sobrevive a restart: recarrega do banco", () => {
   cfg._recarregar(); // simula o boot lendo a tabela
   assert.equal(cfg.tenant("bot-persistente")?.channel, "teams");
   assert.equal(cfg.tenantByWsToken("tok-persistente-1234567890"), "bot-persistente");
+});
+
+test("canal com nome de propriedade do protótipo é recusado", () => {
+  // `OBRIGATORIOS["__proto__"]` resolve pela cadeia de protótipo e é truthy, então
+  // a checagem de canal desconhecido não disparava — barrava só por acidente,
+  // porque a linha seguinte estourava. Agora recusa de propósito.
+  for (const canal of ["__proto__", "constructor", "toString", "valueOf"]) {
+    const r = cfg.registrarTenant("bot-proto", canal, "tok-proto-1234567890abcd", teams);
+    assert.equal(r.ok, false, `aceitou canal ${canal}`);
+    assert.equal(r.status, 400);
+  }
+  assert.equal(cfg.tenant("bot-proto"), null);
+});
+
+test("wsToken não-texto é recusado com 400, não 500", () => {
+  // Número no JSON: `.length` é undefined e `undefined < 16` é false — passava a
+  // validação e só falhava depois, no bind do sqlite.
+  const r = cfg.registrarTenant("bot-numerico", "teams", 12345678901234567890 as any, teams);
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 400);
+  assert.equal(cfg.tenant("bot-numerico"), null);
+});
+
+test("config não-objeto é recusada", () => {
+  for (const c of [null, "texto", 42, ["a"]] as any[]) {
+    const r = cfg.registrarTenant("bot-cfg", "teams", "tok-cfg-1234567890abcdef", c);
+    assert.equal(r.ok, false);
+    assert.equal(r.status, 400);
+  }
+});
+
+test("campo de config não-texto conta como faltando", () => {
+  const r = cfg.registrarTenant("bot-cfg2", "teams", "tok-cfg2-1234567890abcde", {
+    appId: 123,
+    appPassword: "p",
+    tenantId: "t",
+  } as any);
+  assert.equal(r.ok, false);
+  assert.match(r.erro!, /appId/);
 });
 
 test("listagem não vaza wsToken nem segredo de canal", () => {

--- a/src/bridge/config.ts
+++ b/src/bridge/config.ts
@@ -33,7 +33,7 @@
 
 import { timingSafeEqual } from "node:crypto";
 import { env } from "../env";
-import { tenantStore } from "./store";
+import { storeDisponivel, tenantStore } from "./store";
 import { bridgeHub } from "./hub";
 
 export interface TenantDef {
@@ -48,11 +48,34 @@ export type Origem = "env" | "runtime";
 // nome com "/", ".." ou espaço produza rota estranha ou log confuso.
 const NOME_VALIDO = /^[a-z0-9][a-z0-9._-]{1,62}$/;
 
+// Teto de tenants criados em runtime. Guarda-corpo contra laço com bug ou token
+// comprometido enchendo a tabela — não é limite de negócio.
+const MAX_TENANTS_RUNTIME = 200;
+
 // Campos que cada canal precisa ter pra funcionar. Validar no registro impede
 // gravar um tenant que só falharia na primeira mensagem real.
 const OBRIGATORIOS: Record<string, string[]> = {
   teams: ["appId", "appPassword", "tenantId"],
   whatsapp: ["verifyToken", "phoneNumberId", "metaToken"],
+};
+
+// Campo que IDENTIFICA de quem é o tenant, por canal. Um tenant pertence a UMA
+// identidade: no Teams, ao app registration (appId); no WhatsApp, ao número
+// (phoneNumberId).
+//
+// Serve pra distinguir dois casos que o PUT idempotente confundia:
+//
+//   mesma identidade  → é o MESMO bot repetindo o registro (retry de rede, ou
+//                       rotação de segredo). Legítimo, atualiza.
+//   identidade outra  → é OUTRO bot tentando ocupar um nome de tenant que já
+//                       tem dono. Recusa.
+//
+// Sem isso, criar um bot novo com o nome de tenant de um bot existente
+// sobrescrevia as credenciais dele e derrubava a conexão viva: o bot antigo
+// emudecia em produção e a criação do novo reportava sucesso.
+const IDENTIDADE: Record<string, string> = {
+  teams: "appId",
+  whatsapp: "phoneNumberId",
 };
 
 function parseEnvTenants(): Record<string, TenantDef> {
@@ -139,20 +162,48 @@ export function registrarTenant(
   wsToken: string,
   config: Record<string, any>,
 ): ResultadoRegistro {
-  if (!name || !NOME_VALIDO.test(name)) {
+  // Sem a tabela, registrar em runtime não é possível — responde 503 explícito em
+  // vez de estourar no INSERT e virar 500.
+  if (!storeDisponivel()) {
+    return { ok: false, status: 503, erro: "armazenamento de tenants indisponível (ver log do boot)" };
+  }
+  if (typeof name !== "string" || !NOME_VALIDO.test(name)) {
     return { ok: false, status: 400, erro: "nome inválido (use a-z, 0-9, . _ -, 2 a 63 chars)" };
+  }
+  // Teto no número de tenants de runtime: sem isso um token comprometido (ou um
+  // laço com bug do lado do control-plane) enche a tabela e o Map em memória
+  // indefinidamente. O número é folgado — a Limppano tem 10 empresas.
+  if (runtimeTenants.size >= MAX_TENANTS_RUNTIME && !runtimeTenants.has(name)) {
+    return {
+      ok: false,
+      status: 507,
+      erro: `limite de ${MAX_TENANTS_RUNTIME} tenants de runtime atingido — remova algum antes de criar outro`,
+    };
   }
   if (envTenants[name]) {
     // 409 e não 403: o nome existe, só não é gravável por aqui.
     return { ok: false, status: 409, erro: `tenant "${name}" vem do env e não pode ser alterado em runtime` };
   }
-  if (!channel || !OBRIGATORIOS[channel]) {
+  // Object.hasOwn e não `!OBRIGATORIOS[channel]`: a chave vem do corpo da
+  // requisição, e `OBRIGATORIOS["__proto__"]` ou `["constructor"]` resolve pela
+  // cadeia de protótipo pra algo truthy — a checagem de "canal desconhecido"
+  // não disparava. Hoje o efeito era só um 500 na linha seguinte (Object não
+  // tem .filter), mas depender de um crash acidental pra barrar entrada não é
+  // barreira. (CWE-1321)
+  if (!channel || !Object.hasOwn(OBRIGATORIOS, channel)) {
     return { ok: false, status: 400, erro: `canal desconhecido: ${channel || "(vazio)"}` };
   }
-  if (!wsToken || wsToken.length < 16) {
-    return { ok: false, status: 400, erro: "wsToken ausente ou curto demais (mínimo 16 chars)" };
+  // typeof antes de .length: se wsToken vier como número no JSON, `.length` é
+  // undefined e `undefined < 16` é false — a validação PASSAVA com um valor que
+  // não é string, e o erro só aparecia depois, no bind do sqlite, como 500.
+  if (typeof wsToken !== "string" || wsToken.length < 16) {
+    return { ok: false, status: 400, erro: "wsToken ausente, não-texto, ou curto demais (mínimo 16 chars)" };
   }
-  const faltando = OBRIGATORIOS[channel].filter((k) => !config?.[k]);
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    return { ok: false, status: 400, erro: "config precisa ser um objeto" };
+  }
+  const obrigatorios = OBRIGATORIOS[channel] ?? [];
+  const faltando = obrigatorios.filter((k) => typeof config[k] !== "string" || !config[k]);
   if (faltando.length) {
     return { ok: false, status: 400, erro: `config do canal ${channel} sem: ${faltando.join(", ")}` };
   }
@@ -166,6 +217,27 @@ export function registrarTenant(
   }
 
   const anterior = runtimeTenants.get(name);
+
+  // O tenant já existe: só o MESMO dono pode reescrever. Outro bot tentando
+  // ocupar o nome é recusado, não atendido silenciosamente.
+  if (anterior) {
+    if (anterior.channel !== channel) {
+      return { ok: false, status: 409, erro: `tenant "${name}" já existe no canal ${anterior.channel}` };
+    }
+    const campo = IDENTIDADE[channel];
+    const donoAtual = campo ? anterior.config?.[campo] : undefined;
+    const donoNovo = campo ? config?.[campo] : undefined;
+    if (campo && donoAtual && donoAtual !== donoNovo) {
+      return {
+        ok: false,
+        status: 409,
+        erro:
+          `tenant "${name}" já pertence a outro ${campo} (${donoAtual}) — ` +
+          `sobrescrever derrubaria a ponte dele. Use outro nome de tenant.`,
+      };
+    }
+  }
+
   tenantStore.gravar(name, channel, wsToken, config);
   runtimeTenants.set(name, { wsToken, channel, config });
 

--- a/src/bridge/config.ts
+++ b/src/bridge/config.ts
@@ -1,7 +1,18 @@
 // config.ts — configuração multi-tenant, multi-canal da ponte.
 //
 // Um tenant = um app/agente interno que DISCA pro gateway (WebSocket) e recebe
-// as mensagens de UM canal (whatsapp, teams...). Config vem de env em JSON:
+// as mensagens de UM canal (whatsapp, teams...).
+//
+// Duas fontes, nesta ordem de precedência:
+//
+//   1. ENV (`BRIDGE_TENANTS`) — base fixa, lida no boot. É onde vivem os tenants
+//      de produção (sac, crm...). NUNCA pode ser sobrescrita em runtime.
+//   2. BANCO (tabela bridge_tenants) — tenants criados pela plataforma de
+//      agentes em runtime, sem reiniciar o gateway.
+//
+// A precedência do env é uma garantia de segurança, não estética: a rota de
+// registro é autenticada por um token só, e se ela pudesse regravar o tenant
+// "sac" um bot novo herdaria o WhatsApp de produção do SAC.
 //
 //   BRIDGE_TENANTS = {
 //     "sac": {
@@ -19,10 +30,11 @@
 //       "config": { "appId": "...", "appPassword": "...", "tenantId": "..." }
 //     }
 //   }
-//
-// Adicionar app novo = adicionar um tenant aqui. Zero rota nova.
 
+import { timingSafeEqual } from "node:crypto";
 import { env } from "../env";
+import { tenantStore } from "./store";
+import { bridgeHub } from "./hub";
 
 export interface TenantDef {
   wsToken: string;
@@ -30,7 +42,20 @@ export interface TenantDef {
   config: Record<string, any>;
 }
 
-function parseTenants(): Record<string, TenantDef> {
+export type Origem = "env" | "runtime";
+
+// O nome vira segmento de URL (/ingress/:tenant). Restringir aqui evita que um
+// nome com "/", ".." ou espaço produza rota estranha ou log confuso.
+const NOME_VALIDO = /^[a-z0-9][a-z0-9._-]{1,62}$/;
+
+// Campos que cada canal precisa ter pra funcionar. Validar no registro impede
+// gravar um tenant que só falharia na primeira mensagem real.
+const OBRIGATORIOS: Record<string, string[]> = {
+  teams: ["appId", "appPassword", "tenantId"],
+  whatsapp: ["verifyToken", "phoneNumberId", "metaToken"],
+};
+
+function parseEnvTenants(): Record<string, TenantDef> {
   try {
     const p = JSON.parse(env.BRIDGE_TENANTS || "{}");
     return p && typeof p === "object" ? p : {};
@@ -40,21 +65,146 @@ function parseTenants(): Record<string, TenantDef> {
   }
 }
 
-const tenants = parseTenants();
+const envTenants: Record<string, TenantDef> = parseEnvTenants();
+const runtimeTenants = new Map<string, TenantDef>();
 
-// nome do tenant -> def
+// Carrega o que já estava gravado. Um tenant de runtime com nome de tenant do
+// env é IGNORADO (o env ganha) — pode acontecer se alguém promoveu pro env
+// depois. Não apaga a linha: promoção pode ser revertida.
+function carregarDoBanco(): void {
+  runtimeTenants.clear();
+  let ignorados = 0;
+  for (const row of tenantStore.listar()) {
+    if (envTenants[row.name]) {
+      ignorados++;
+      continue;
+    }
+    runtimeTenants.set(row.name, { wsToken: row.wsToken, channel: row.channel, config: row.config });
+  }
+  const n = runtimeTenants.size;
+  console.log(
+    `[bridge.config] tenants: ${Object.keys(envTenants).length} do env, ${n} do banco` +
+      (ignorados ? ` (${ignorados} ignorado(s): nome já existe no env)` : ""),
+  );
+}
+carregarDoBanco();
+
+// nome do tenant -> def. Env primeiro.
 export function tenant(name: string | undefined): TenantDef | null {
   if (!name) return null;
-  return tenants[name] || null;
+  return envTenants[name] || runtimeTenants.get(name) || null;
+}
+
+export function origemDoTenant(name: string): Origem | null {
+  if (envTenants[name]) return "env";
+  if (runtimeTenants.has(name)) return "runtime";
+  return null;
+}
+
+// Comparação de segredo em tempo constante. `===` em string vaza o tamanho do
+// prefixo comum pelo tempo — irrelevante isolado, mas isto é o caminho de auth
+// da ponte e o custo de fazer certo é zero.
+function tokensIguais(a: string, b: string): boolean {
+  const ba = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
 }
 
 // wsToken -> nome do tenant (pra autenticar a conexão WebSocket)
 export function tenantByWsToken(token: string | undefined): string | null {
   if (!token) return null;
-  for (const [name, def] of Object.entries(tenants)) {
-    if (def.wsToken && def.wsToken === token) return name;
+  for (const [name, def] of Object.entries(envTenants)) {
+    if (def.wsToken && tokensIguais(def.wsToken, token)) return name;
+  }
+  for (const [name, def] of runtimeTenants) {
+    if (def.wsToken && tokensIguais(def.wsToken, token)) return name;
   }
   return null;
 }
 
-export const bridgeConfig = { tenants };
+export interface ResultadoRegistro {
+  ok: boolean;
+  status: number;
+  erro?: string;
+  criado?: boolean;
+}
+
+// registrarTenant grava/atualiza um tenant de runtime. Idempotente: repetir com
+// os mesmos valores devolve ok sem efeito colateral (a plataforma de agentes
+// pode ter retry).
+export function registrarTenant(
+  name: string,
+  channel: string,
+  wsToken: string,
+  config: Record<string, any>,
+): ResultadoRegistro {
+  if (!name || !NOME_VALIDO.test(name)) {
+    return { ok: false, status: 400, erro: "nome inválido (use a-z, 0-9, . _ -, 2 a 63 chars)" };
+  }
+  if (envTenants[name]) {
+    // 409 e não 403: o nome existe, só não é gravável por aqui.
+    return { ok: false, status: 409, erro: `tenant "${name}" vem do env e não pode ser alterado em runtime` };
+  }
+  if (!channel || !OBRIGATORIOS[channel]) {
+    return { ok: false, status: 400, erro: `canal desconhecido: ${channel || "(vazio)"}` };
+  }
+  if (!wsToken || wsToken.length < 16) {
+    return { ok: false, status: 400, erro: "wsToken ausente ou curto demais (mínimo 16 chars)" };
+  }
+  const faltando = OBRIGATORIOS[channel].filter((k) => !config?.[k]);
+  if (faltando.length) {
+    return { ok: false, status: 400, erro: `config do canal ${channel} sem: ${faltando.join(", ")}` };
+  }
+
+  // Colisão de wsToken com OUTRO tenant tornaria ambíguo quem está discando.
+  const donoEnv = Object.entries(envTenants).find(([, d]) => d.wsToken === wsToken)?.[0];
+  if (donoEnv) return { ok: false, status: 409, erro: "wsToken já pertence a um tenant do env" };
+  const donoBanco = tenantStore.donoDoToken(wsToken);
+  if (donoBanco && donoBanco !== name) {
+    return { ok: false, status: 409, erro: `wsToken já pertence ao tenant "${donoBanco}"` };
+  }
+
+  const anterior = runtimeTenants.get(name);
+  tenantStore.gravar(name, channel, wsToken, config);
+  runtimeTenants.set(name, { wsToken, channel, config });
+
+  // Se o token MUDOU, quem estava conectado com o antigo tem que cair. Sem isso
+  // "trocar a credencial" não revogaria nada: a conexão velha segue aberta e
+  // recebendo mensagens até o processo reiniciar.
+  if (anterior && anterior.wsToken !== wsToken) {
+    const n = bridgeHub.derrubar(name, "credencial trocada");
+    console.log(`[bridge.config] tenant "${name}": wsToken trocado, ${n} conexão(ões) derrubada(s)`);
+  }
+
+  console.log(`[bridge.config] tenant "${name}" (${channel}) ${anterior ? "atualizado" : "registrado"}`);
+  return { ok: true, status: anterior ? 200 : 201, criado: !anterior };
+}
+
+export function removerTenant(name: string): ResultadoRegistro {
+  if (envTenants[name]) {
+    return { ok: false, status: 409, erro: `tenant "${name}" vem do env e não pode ser removido em runtime` };
+  }
+  const existia = tenantStore.remover(name);
+  runtimeTenants.delete(name);
+  // Remover sem derrubar deixaria a ponte aberta entregando mensagens de um
+  // tenant que "não existe mais" — revogação tem que ser efetiva.
+  const n = bridgeHub.derrubar(name, "tenant removido");
+  if (!existia) return { ok: false, status: 404, erro: "tenant não encontrado" };
+  console.log(`[bridge.config] tenant "${name}" removido (${n} conexão(ões) derrubada(s))`);
+  return { ok: true, status: 200 };
+}
+
+// Listagem SEM segredo: nome, canal e origem. wsToken e config (que carrega
+// appPassword/metaToken) nunca saem por aqui.
+export function listarTenants(): Array<{ name: string; channel: string; origem: Origem }> {
+  const out: Array<{ name: string; channel: string; origem: Origem }> = [];
+  for (const [name, def] of Object.entries(envTenants)) out.push({ name, channel: def.channel, origem: "env" });
+  for (const [name, def] of runtimeTenants) out.push({ name, channel: def.channel, origem: "runtime" });
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// Só pra teste: recarrega o estado em memória a partir do banco.
+export function _recarregar(): void {
+  carregarDoBanco();
+}

--- a/src/bridge/controller.test.ts
+++ b/src/bridge/controller.test.ts
@@ -1,0 +1,135 @@
+// controller.test.ts — testes nas ROTAS HTTP de administração de tenant.
+//
+// Separado de config.test.ts de propósito: lá o alvo é a lógica de precedência
+// e revogação; aqui é a camada que decide 401/429/503/413 ANTES de qualquer
+// lógica de negócio rodar. Um erro aqui abre a porta sem nem chegar nas regras
+// que o outro arquivo protege.
+//
+// Usa `app.request()` do Hono — não sobe servidor, não abre porta.
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ADMIN = "tok-admin-de-teste-com-tamanho-suficiente";
+const TOK_ENV = "tok-sac-de-producao-nao-toque";
+
+let dir: string;
+let app: any;
+
+const teams = { appId: "app-1", appPassword: "p", tenantId: "t" };
+
+function put(nome: string, corpo: unknown, token?: string) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (token) headers.authorization = `Bearer ${token}`;
+  return app.request(`/bridge/tenants/${nome}`, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify(corpo),
+  });
+}
+
+before(async () => {
+  dir = mkdtempSync(join(tmpdir(), "wagw-ctrl-"));
+  process.env.DB_PATH = join(dir, "test.db");
+  process.env.ADMIN_USER = "t";
+  process.env.ADMIN_PASSWORD = "t";
+  process.env.BRIDGE_ADMIN_TOKEN = ADMIN;
+  process.env.BRIDGE_TENANTS = JSON.stringify({
+    sac: {
+      wsToken: TOK_ENV,
+      channel: "whatsapp",
+      config: { verifyToken: "v", phoneNumberId: "1", metaToken: "m" },
+    },
+  });
+  const { createBridgeController } = await import("./controller");
+  app = createBridgeController();
+});
+
+after(() => rmSync(dir, { recursive: true, force: true }));
+
+test("PUT sem token é 401", async () => {
+  const r = await put("bot-a", { channel: "teams", wsToken: "tok-a-1234567890abcdef", config: teams });
+  assert.equal(r.status, 401);
+});
+
+test("PUT com token errado é 401", async () => {
+  const r = await put("bot-a", { channel: "teams", wsToken: "tok-a-1234567890abcdef", config: teams }, "errado");
+  assert.equal(r.status, 401);
+});
+
+test("PUT com token certo cria (201)", async () => {
+  const r = await put("bot-a", { channel: "teams", wsToken: "tok-a-1234567890abcdef", config: teams }, ADMIN);
+  assert.equal(r.status, 201);
+  assert.equal((await r.json()).criado, true);
+});
+
+test("corpo acima de 16KB é 413, antes de parsear", async () => {
+  const gigante = { channel: "teams", wsToken: "tok-big-1234567890abcdef", config: { ...teams, appId: "x".repeat(20_000) } };
+  const r = await put("bot-big", gigante, ADMIN);
+  assert.equal(r.status, 413);
+});
+
+test("corpo que não é objeto JSON é 400", async () => {
+  const r = await app.request("/bridge/tenants/bot-arr", {
+    method: "PUT",
+    headers: { "content-type": "application/json", authorization: `Bearer ${ADMIN}` },
+    body: JSON.stringify(["não", "é", "objeto"]),
+  });
+  assert.equal(r.status, 400);
+});
+
+test("tentar sobrescrever tenant do env é 409 pela rota", async () => {
+  const r = await put("sac", { channel: "teams", wsToken: "tok-inv-1234567890abcdef", config: teams }, ADMIN);
+  assert.equal(r.status, 409);
+});
+
+test("GET /bridge/status sem token não revela nomes de tenant", async () => {
+  const body = await (await app.request("/bridge/status")).json();
+  assert.equal(typeof body.tenants_conectados, "number");
+  assert.equal(body.tenants_online, undefined, "expôs o mapa nome→conexões sem auth");
+  assert.ok(!JSON.stringify(body).includes("sac"), "vazou nome de tenant");
+});
+
+test("GET /bridge/status com token traz o detalhe", async () => {
+  const r = await app.request("/bridge/status", { headers: { authorization: `Bearer ${ADMIN}` } });
+  const body = await r.json();
+  assert.ok(body.tenants_online, "não trouxe o detalhe pra quem tem token");
+});
+
+test("GET /bridge/tenants não devolve segredo", async () => {
+  const r = await app.request("/bridge/tenants", { headers: { authorization: `Bearer ${ADMIN}` } });
+  const texto = JSON.stringify(await r.json());
+  assert.ok(!texto.includes("tok-"), "vazou wsToken");
+  assert.ok(!texto.includes("appPassword"), "vazou segredo de canal");
+});
+
+// A ordem "confere token → depois olha bloqueio" é o ponto do teste abaixo.
+// Invertida, alguém errando de propósito 10 vezes trancaria o control-plane por
+// um minuto — e atrás de proxy/NAT todos vêm do mesmo IP, então o freio contra
+// força-bruta viraria uma negação de serviço trivial sobre criar bot.
+test("força-bruta é freada em 429, mas o token válido continua passando", async () => {
+  const ip = { "x-forwarded-for": "10.9.9.9" };
+  const errar = () =>
+    app.request("/bridge/tenants", { headers: { ...ip, authorization: "Bearer token-errado-qualquer" } });
+
+  const codigos: number[] = [];
+  for (let i = 0; i < 12; i++) codigos.push((await errar()).status);
+
+  assert.ok(codigos.slice(0, 10).every((c) => c === 401), `esperava 401 nas primeiras: ${codigos}`);
+  assert.ok(codigos.slice(10).every((c) => c === 429), `esperava 429 depois do limite: ${codigos}`);
+
+  const legitimo = await app.request("/bridge/tenants", {
+    headers: { ...ip, authorization: `Bearer ${ADMIN}` },
+  });
+  assert.equal(legitimo.status, 200, "o freio trancou o cliente legítimo do mesmo IP");
+});
+
+test("IP diferente não herda o bloqueio de outro", async () => {
+  const r = await app.request("/bridge/tenants", {
+    headers: { "x-forwarded-for": "10.1.1.1", authorization: "Bearer token-errado-qualquer" },
+  });
+  assert.equal(r.status, 401, "bloqueio vazou entre IPs");
+});

--- a/src/bridge/controller.ts
+++ b/src/bridge/controller.ts
@@ -22,21 +22,93 @@ import { adapterFor } from "./channels";
 import { bridgeHub } from "./hub";
 import { env } from "../env";
 
-// Guarda das rotas de administração de tenant. Fail-closed: sem
-// BRIDGE_ADMIN_TOKEN configurado a rota não existe pra ninguém.
-function adminAutorizado(c: any): { ok: true } | { ok: false; status: number; erro: string } {
-  const esperado = env.BRIDGE_ADMIN_TOKEN;
-  if (!esperado) {
-    return { ok: false, status: 503, erro: "registro de tenant em runtime desabilitado (BRIDGE_ADMIN_TOKEN não configurado)" };
+// Teto do corpo das rotas admin, em bytes. A config de um tenant tem meia dúzia
+// de campos curtos — 16 KB é ~100x o tamanho real.
+const LIMITE_CORPO = 16_384;
+
+// Freio de força-bruta nas rotas admin.
+//
+// Sem isso, quem alcança a rede pode tentar o BRIDGE_ADMIN_TOKEN indefinidamente
+// sem ser bloqueado nem deixar rastro — e acertar dá controle sobre criar,
+// rotacionar e remover qualquer tenant de runtime. O piso de entropia no env
+// (24 chars) torna a busca inviável; este freio garante que ela também seja
+// LENTA e VISÍVEL no log.
+//
+// Janela deslizante simples em memória, por IP. Não é rate limit distribuído —
+// o gateway sobe como instância única (ver compose/deploy) e o objetivo aqui é
+// freio + rastro, não cota precisa.
+const TENTATIVAS_MAX = 10;
+const JANELA_MS = 60_000;
+const tentativas = new Map<string, number[]>();
+
+function ipDaRequisicao(c: any): string {
+  const xff = c.req.header("x-forwarded-for") || "";
+  return (xff.split(",")[0] || "").trim() || c.req.header("x-real-ip") || "desconhecido";
+}
+
+// Só conta FALHA. Um cliente legítimo (o control-plane) nunca acumula.
+function registrarFalha(ip: string, agora: number): number {
+  const recentes = (tentativas.get(ip) || []).filter((t) => agora - t < JANELA_MS);
+  recentes.push(agora);
+  tentativas.set(ip, recentes);
+  // Poda preguiçosa: sem isso o Map cresce indefinidamente com IPs que tentaram
+  // uma vez e nunca voltaram.
+  if (tentativas.size > 1000) {
+    for (const [k, v] of tentativas) {
+      if (v.every((t) => agora - t >= JANELA_MS)) tentativas.delete(k);
+    }
   }
+  return recentes.length;
+}
+
+function bloqueado(ip: string, agora: number): boolean {
+  const recentes = (tentativas.get(ip) || []).filter((t) => agora - t < JANELA_MS);
+  return recentes.length >= TENTATIVAS_MAX;
+}
+
+// tokenAdminConfere compara o token da requisição, SEM contar tentativa nem
+// logar. Usado por rota onde "sem token" é caso legítimo (o /bridge/status, que
+// é health check) — ali um token ausente não é ataque e não pode consumir o
+// orçamento de tentativas de quem monitora.
+function tokenAdminConfere(c: any): boolean {
+  const esperado = env.BRIDGE_ADMIN_TOKEN;
+  if (!esperado) return false;
   const bearer = (c.req.header("authorization") || "").replace(/^Bearer\s+/i, "");
   const recebido = bearer || c.req.header("x-bridge-admin-token") || "";
   const a = Buffer.from(recebido);
   const b = Buffer.from(esperado);
-  if (a.length !== b.length || !timingSafeEqual(a, b)) {
-    return { ok: false, status: 401, erro: "token inválido" };
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+// Guarda das rotas de administração de tenant. Fail-closed: sem
+// BRIDGE_ADMIN_TOKEN configurado a rota não existe pra ninguém. Aqui um token
+// errado É tentativa, então conta e loga.
+function adminAutorizado(c: any): { ok: true } | { ok: false; status: number; erro: string } {
+  if (!env.BRIDGE_ADMIN_TOKEN) {
+    return { ok: false, status: 503, erro: "registro de tenant em runtime desabilitado (BRIDGE_ADMIN_TOKEN não configurado)" };
   }
-  return { ok: true };
+
+  // Confere o token ANTES de olhar o bloqueio, e deixa passar quem acertou mesmo
+  // que o IP esteja bloqueado.
+  //
+  // Ordem importa: o freio existe pra atrasar quem está ADIVINHANDO, e quem tem
+  // o token certo não está. Checando o bloqueio primeiro, alguém errando de
+  // propósito 10 vezes travaria o control-plane por 1 minuto — e, atrás de um
+  // proxy/NAT compartilhado, todo mundo vem do mesmo IP. Isso transformaria a
+  // proteção contra força-bruta numa negação de serviço fácil sobre criar bot.
+  // Como força-bruta por definição nunca chega a acertar, liberar o acerto não
+  // enfraquece nada.
+  if (tokenAdminConfere(c)) return { ok: true };
+
+  const ip = ipDaRequisicao(c);
+  const agora = Date.now();
+  if (bloqueado(ip, agora)) {
+    console.warn(`[bridge.admin] BLOQUEADO por excesso de tentativas: ip=${ip}`);
+    return { ok: false, status: 429, erro: "muitas tentativas — tente novamente em 1 minuto" };
+  }
+  const n = registrarFalha(ip, agora);
+  console.warn(`[bridge.admin] token inválido: ip=${ip} tentativa=${n}/${TENTATIVAS_MAX}`);
+  return { ok: false, status: 401, erro: "token inválido" };
 }
 
 export const createBridgeController = () => {
@@ -122,8 +194,30 @@ export const createBridgeController = () => {
     return c.json({ success: r.ok, id: r.id ?? null, error: r.error ?? null }, r.ok ? 200 : 502);
   });
 
-  // GET /bridge/status
-  app.get("/bridge/status", (c) => c.json({ tenants_online: bridgeHub.status() }));
+  // GET /bridge/status — health da ponte.
+  //
+  // Sem token devolve só a CONTAGEM. Antes devolvia o mapa nome→conexões sem
+  // auth nenhuma, e com o registro em runtime isso piorou: a população de
+  // tenants passou a ser dinâmica e vinda de fora, então a rota entregava de
+  // graça os nomes dos bots criados pela plataforma. Nome de tenant é o que
+  // compõe /ingress/:tenant, que é webhook público — dar a lista é entregar o
+  // alvo.
+  //
+  // Com token, o detalhe por tenant continua disponível (é o uso real de debug).
+  app.get("/bridge/status", (c) => {
+    const detalhe = bridgeHub.status();
+    // tokenAdminConfere (e não adminAutorizado): sem token é uso legítimo aqui,
+    // não tentativa de invasão — não pode consumir o orçamento de tentativas de
+    // quem só está monitorando.
+    if (tokenAdminConfere(c)) {
+      return c.json({ tenants_online: detalhe });
+    }
+    const nomes = Object.keys(detalhe);
+    return c.json({
+      tenants_conectados: nomes.length,
+      pontes_abertas: nomes.reduce((n, k) => n + (detalhe[k] ?? 0), 0),
+    });
+  });
 
   // ── Administração de tenants em RUNTIME ────────────────────────────────────
   // Quem chama é o control-plane da plataforma de agentes, ao provisionar um bot.
@@ -143,13 +237,42 @@ export const createBridgeController = () => {
     if (!auth.ok) return c.json({ success: false, error: auth.erro }, auth.status as any);
 
     const name = c.req.param("name");
+
+    // Teto de corpo: a config de um tenant tem meia dúzia de campos curtos, e
+    // ler JSON sem limite deixa a rota servir de vetor de memória. 16 KB é ~100x
+    // o tamanho real.
+    //
+    // Duas checagens de propósito. O header é o atalho — corta antes de ler
+    // qualquer byte quando o cliente é honesto sobre o tamanho. Mas ele é
+    // OPCIONAL: requisição com transfer-encoding chunked não manda
+    // content-length, e confiar só nele deixava o limite ser contornado com uma
+    // flag de cliente. A segunda checagem é sobre os bytes que realmente
+    // chegaram.
+    const declarado = Number(c.req.header("content-length") || 0);
+    if (declarado > LIMITE_CORPO) {
+      return c.json({ success: false, error: "corpo grande demais (máximo 16KB)" }, 413);
+    }
+
+    let bruto: string;
+    try {
+      bruto = await c.req.text();
+    } catch {
+      return c.json({ success: false, error: "não foi possível ler o corpo" }, 400);
+    }
+    if (bruto.length > LIMITE_CORPO) {
+      return c.json({ success: false, error: "corpo grande demais (máximo 16KB)" }, 413);
+    }
+
     let body: any;
     try {
-      body = await c.req.json();
+      body = JSON.parse(bruto);
     } catch {
       return c.json({ success: false, error: "corpo inválido (esperado JSON)" }, 400);
     }
-    const r = registrarTenant(name, body?.channel, body?.wsToken, body?.config || {});
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return c.json({ success: false, error: "corpo precisa ser um objeto JSON" }, 400);
+    }
+    const r = registrarTenant(name, body.channel, body.wsToken, body.config || {});
     if (!r.ok) return c.json({ success: false, error: r.erro }, r.status as any);
     return c.json({ success: true, name, criado: r.criado === true }, r.status as any);
   });

--- a/src/bridge/controller.ts
+++ b/src/bridge/controller.ts
@@ -8,10 +8,36 @@
 //
 // Roteia pelo :tenant (config diz qual canal) — adicionar app/canal = só config.
 
+import { timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
-import { tenant as tenantDef, tenantByWsToken } from "./config";
+import {
+  listarTenants,
+  origemDoTenant,
+  registrarTenant,
+  removerTenant,
+  tenant as tenantDef,
+  tenantByWsToken,
+} from "./config";
 import { adapterFor } from "./channels";
 import { bridgeHub } from "./hub";
+import { env } from "../env";
+
+// Guarda das rotas de administração de tenant. Fail-closed: sem
+// BRIDGE_ADMIN_TOKEN configurado a rota não existe pra ninguém.
+function adminAutorizado(c: any): { ok: true } | { ok: false; status: number; erro: string } {
+  const esperado = env.BRIDGE_ADMIN_TOKEN;
+  if (!esperado) {
+    return { ok: false, status: 503, erro: "registro de tenant em runtime desabilitado (BRIDGE_ADMIN_TOKEN não configurado)" };
+  }
+  const bearer = (c.req.header("authorization") || "").replace(/^Bearer\s+/i, "");
+  const recebido = bearer || c.req.header("x-bridge-admin-token") || "";
+  const a = Buffer.from(recebido);
+  const b = Buffer.from(esperado);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    return { ok: false, status: 401, erro: "token inválido" };
+  }
+  return { ok: true };
+}
 
 export const createBridgeController = () => {
   const app = new Hono();
@@ -40,10 +66,37 @@ export const createBridgeController = () => {
     const headers: Record<string, string> = {};
     c.req.raw.headers.forEach((v, k) => (headers[k] = v));
 
-    // Responde 200 rápido; processa/empurra em background (webhooks têm timeout).
-    processarEntrada(adapter, rawBody, headers, t, name).catch((e) =>
-      console.error(`[bridge] erro processando entrada de ${name}:`, e?.message || e),
-    );
+    // receive() é rápido (valida/parseia); o trabalho pesado (o agente) roda do
+    // outro lado da ponte. Alguns eventos exigem uma resposta HTTP específica
+    // (ex: Teams fileConsent/invoke → InvokeResponse) — por isso aguardamos aqui.
+    let result: Awaited<ReturnType<typeof adapter.receive>> = null;
+    try {
+      result = await adapter.receive(rawBody, headers, t);
+    } catch (e: any) {
+      console.error(`[bridge] erro processando entrada de ${name}:`, e?.message || e);
+      return c.text("ok"); // não vaza erro pro canal
+    }
+
+    if (result?.response) {
+      const r = result.response;
+      if (r.json !== undefined) return c.json(r.json as any, r.status as any);
+      return c.body(r.body ?? "", r.status as any);
+    }
+    if (result?.push) {
+      // Entrega protegida: antes isto rodava em background com .catch(), então
+      // exceção aqui NUNCA podia afetar a resposta HTTP. Ao trazer pro caminho
+      // síncrono (necessário pro InvokeResponse do Teams), uma exceção subiria
+      // pro middleware de erro e devolveria 500 ao webhook — e 500 pra Meta
+      // significa RETRY, ou seja, mensagem de WhatsApp entregue duas vezes ao
+      // app e possivelmente resposta duplicada pro cliente. O canal já recebeu a
+      // mensagem; falha na ponte é problema nosso, não motivo pra pedir reenvio.
+      try {
+        const n = bridgeHub.entregar(name, { type: "message", ...(result.push as object) });
+        console.log(`[bridge] ${adapter.name} → tenant "${name}" (${n} ponte(s))`);
+      } catch (e: any) {
+        console.error(`[bridge] falha entregando na ponte de ${name}:`, e?.message || e);
+      }
+    }
     return c.text("ok");
   });
 
@@ -72,19 +125,63 @@ export const createBridgeController = () => {
   // GET /bridge/status
   app.get("/bridge/status", (c) => c.json({ tenants_online: bridgeHub.status() }));
 
+  // ── Administração de tenants em RUNTIME ────────────────────────────────────
+  // Quem chama é o control-plane da plataforma de agentes, ao provisionar um bot.
+  // Antes disso, um bot novo só passava a existir editando BRIDGE_TENANTS e
+  // REINICIANDO o gateway — o que derruba a ponte de todos os bots no ar.
+
+  // GET /bridge/tenants — nome, canal e origem. Sem segredo no corpo.
+  app.get("/bridge/tenants", (c) => {
+    const auth = adminAutorizado(c);
+    if (!auth.ok) return c.json({ success: false, error: auth.erro }, auth.status as any);
+    return c.json({ success: true, tenants: listarTenants(), online: bridgeHub.status() });
+  });
+
+  // PUT /bridge/tenants/:name — cria ou atualiza. Idempotente.
+  app.put("/bridge/tenants/:name", async (c) => {
+    const auth = adminAutorizado(c);
+    if (!auth.ok) return c.json({ success: false, error: auth.erro }, auth.status as any);
+
+    const name = c.req.param("name");
+    let body: any;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ success: false, error: "corpo inválido (esperado JSON)" }, 400);
+    }
+    const r = registrarTenant(name, body?.channel, body?.wsToken, body?.config || {});
+    if (!r.ok) return c.json({ success: false, error: r.erro }, r.status as any);
+    return c.json({ success: true, name, criado: r.criado === true }, r.status as any);
+  });
+
+  // DELETE /bridge/tenants/:name
+  app.delete("/bridge/tenants/:name", (c) => {
+    const auth = adminAutorizado(c);
+    if (!auth.ok) return c.json({ success: false, error: auth.erro }, auth.status as any);
+
+    const name = c.req.param("name");
+    const r = removerTenant(name);
+    if (!r.ok) return c.json({ success: false, error: r.erro }, r.status as any);
+    return c.json({ success: true, name });
+  });
+
+  // GET /bridge/tenants/:name — existe? de onde vem? está online?
+  app.get("/bridge/tenants/:name", (c) => {
+    const auth = adminAutorizado(c);
+    if (!auth.ok) return c.json({ success: false, error: auth.erro }, auth.status as any);
+
+    const name = c.req.param("name");
+    const origem = origemDoTenant(name);
+    if (!origem) return c.json({ success: false, error: "tenant não encontrado" }, 404);
+    const t = tenantDef(name)!;
+    return c.json({
+      success: true,
+      name,
+      channel: t.channel,
+      origem,
+      pontes: bridgeHub.status()[name] || 0,
+    });
+  });
+
   return app;
 };
-
-async function processarEntrada(
-  adapter: ReturnType<typeof adapterFor>,
-  rawBody: string,
-  headers: Record<string, string>,
-  t: ReturnType<typeof tenantDef>,
-  name: string,
-): Promise<void> {
-  if (!adapter || !t) return;
-  const result = await adapter.receive(rawBody, headers, t);
-  if (!result?.push) return;
-  const n = bridgeHub.entregar(name, { type: "message", ...(result.push as object) });
-  console.log(`[bridge] ${adapter.name} → tenant "${name}" (${n} ponte(s))`);
-}

--- a/src/bridge/hub.ts
+++ b/src/bridge/hub.ts
@@ -42,6 +42,32 @@ class BridgeHub {
     return n;
   }
 
+  // Fecha todas as pontes abertas de um app. Usado quando a credencial dele é
+  // trocada ou o tenant é removido: sem isso a conexão autenticada com o token
+  // ANTIGO continua aberta e recebendo mensagens até o processo reiniciar —
+  // revogar deixaria de revogar de fato. Retorna quantas foram fechadas.
+  derrubar(app: string, motivo: string): number {
+    const set = this.conexoes.get(app);
+    if (!set || set.size === 0) return 0;
+    let n = 0;
+    for (const socket of [...set]) {
+      try {
+        socket.close(4003, motivo);
+      } catch {
+        try {
+          socket.terminate();
+        } catch {
+          /* já morto */
+        }
+      }
+      n++;
+    }
+    // Não espera o handler de 'close': quem foi derrubado sai do registro agora.
+    this.conexoes.delete(app);
+    console.log(`[bridge.hub] app "${app}": ${n} ponte(s) derrubada(s) — ${motivo}`);
+    return n;
+  }
+
   status(): Record<string, number> {
     const out: Record<string, number> = {};
     for (const [app, set] of this.conexoes) out[app] = set.size;

--- a/src/bridge/store.ts
+++ b/src/bridge/store.ts
@@ -21,21 +21,43 @@ export interface TenantRow {
   updatedAt: string;
 }
 
-db.exec(`
-  CREATE TABLE IF NOT EXISTS bridge_tenants (
-    name       TEXT PRIMARY KEY,
-    channel    TEXT NOT NULL,
-    ws_token   TEXT NOT NULL,
-    config     TEXT NOT NULL DEFAULT '{}',
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
-  );
-`);
+// Disponível = a tabela existe e é usável. Quando false, o gateway segue no ar
+// em modo "só env" em vez de não subir.
+//
+// Por que não deixar a exceção subir: este módulo é carregado no boot, e um
+// problema de sqlite (disco cheio, arquivo corrompido) derrubaria o processo
+// inteiro — junto com os tenants de PRODUÇÃO que vêm do env e não dependem
+// desta tabela pra nada. A feature nova não pode virar ponto único de falha de
+// um serviço que atende WhatsApp de cliente.
+let disponivel = true;
+try {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS bridge_tenants (
+      name       TEXT PRIMARY KEY,
+      channel    TEXT NOT NULL,
+      ws_token   TEXT NOT NULL,
+      config     TEXT NOT NULL DEFAULT '{}',
+      created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
 
-// O wsToken é a credencial da ponte: dois tenants com o mesmo token tornariam
-// ambíguo quem está discando (tenantByWsToken devolve o PRIMEIRO que casa). O
-// índice único transforma isso em erro de escrita em vez de bug silencioso.
-db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_bridge_tenants_ws_token ON bridge_tenants(ws_token);`);
+  // O wsToken é a credencial da ponte: dois tenants com o mesmo token tornariam
+  // ambíguo quem está discando (tenantByWsToken devolve o PRIMEIRO que casa). O
+  // índice único transforma isso em erro de escrita em vez de bug silencioso.
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_bridge_tenants_ws_token ON bridge_tenants(ws_token);`);
+} catch (e) {
+  disponivel = false;
+  console.error(
+    "[bridge.store] NÃO foi possível preparar a tabela bridge_tenants:",
+    (e as Error).message,
+    "— registro de tenant em runtime fica INDISPONÍVEL; o gateway segue com os tenants do BRIDGE_TENANTS.",
+  );
+}
+
+export function storeDisponivel(): boolean {
+  return disponivel;
+}
 
 function paraRow(r: any): TenantRow {
   let config: Record<string, any> = {};
@@ -59,11 +81,13 @@ function paraRow(r: any): TenantRow {
 
 export const tenantStore = {
   listar(): TenantRow[] {
+    if (!disponivel) return [];
     const rows = db.prepare("SELECT * FROM bridge_tenants ORDER BY name").all() as any[];
     return rows.map(paraRow);
   },
 
   buscar(name: string): TenantRow | null {
+    if (!disponivel) return null;
     const r = db.prepare("SELECT * FROM bridge_tenants WHERE name = ?").get(name) as any;
     return r ? paraRow(r) : null;
   },
@@ -71,6 +95,7 @@ export const tenantStore = {
   // Idempotente de propósito: a plataforma de agentes pode repetir a chamada
   // (retry de rede, recriar o bot) e o resultado tem que ser o mesmo.
   gravar(name: string, channel: string, wsToken: string, config: Record<string, any>): TenantRow {
+    if (!disponivel) throw new Error("tabela bridge_tenants indisponível");
     db.prepare(
       `INSERT INTO bridge_tenants (name, channel, ws_token, config, updated_at)
        VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
@@ -84,11 +109,13 @@ export const tenantStore = {
   },
 
   remover(name: string): boolean {
+    if (!disponivel) return false;
     return db.prepare("DELETE FROM bridge_tenants WHERE name = ?").run(name).changes > 0;
   },
 
   // Dono de um wsToken (pra detectar colisão antes de gravar).
   donoDoToken(wsToken: string): string | null {
+    if (!disponivel) return null;
     const r = db.prepare("SELECT name FROM bridge_tenants WHERE ws_token = ?").get(wsToken) as any;
     return r ? (r.name as string) : null;
   },

--- a/src/bridge/store.ts
+++ b/src/bridge/store.ts
@@ -1,0 +1,95 @@
+// store.ts — persistência dos tenants criados em RUNTIME (pela plataforma de
+// agentes), no mesmo sqlite do resto do gateway.
+//
+// Por que existe: até aqui um tenant só nascia de `BRIDGE_TENANTS`, lido UMA vez
+// no boot. Em produção isso significa que criar um bot novo pela plataforma
+// exigia editar o .env e REINICIAR o gateway — derrubando a ponte de todos os
+// outros bots que estavam no ar. Com a tabela, o tenant novo entra na hora e
+// continua existindo depois de um restart.
+//
+// Os tenants do env continuam sendo a base e têm PRECEDÊNCIA (ver config.ts):
+// nada gravado aqui pode sobrescrever um tenant de produção declarado no env.
+
+import db from "../database/db";
+
+export interface TenantRow {
+  name: string;
+  channel: string;
+  wsToken: string;
+  config: Record<string, any>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS bridge_tenants (
+    name       TEXT PRIMARY KEY,
+    channel    TEXT NOT NULL,
+    ws_token   TEXT NOT NULL,
+    config     TEXT NOT NULL DEFAULT '{}',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+`);
+
+// O wsToken é a credencial da ponte: dois tenants com o mesmo token tornariam
+// ambíguo quem está discando (tenantByWsToken devolve o PRIMEIRO que casa). O
+// índice único transforma isso em erro de escrita em vez de bug silencioso.
+db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_bridge_tenants_ws_token ON bridge_tenants(ws_token);`);
+
+function paraRow(r: any): TenantRow {
+  let config: Record<string, any> = {};
+  try {
+    const p = JSON.parse(r.config || "{}");
+    if (p && typeof p === "object") config = p;
+  } catch {
+    // Config corrompida no banco não pode derrubar o boot do gateway — o tenant
+    // sobe com config vazia e o adapter dele reclama na primeira mensagem.
+    console.error(`[bridge.store] config inválida no tenant "${r.name}" — usando {}`);
+  }
+  return {
+    name: r.name,
+    channel: r.channel,
+    wsToken: r.ws_token,
+    config,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+export const tenantStore = {
+  listar(): TenantRow[] {
+    const rows = db.prepare("SELECT * FROM bridge_tenants ORDER BY name").all() as any[];
+    return rows.map(paraRow);
+  },
+
+  buscar(name: string): TenantRow | null {
+    const r = db.prepare("SELECT * FROM bridge_tenants WHERE name = ?").get(name) as any;
+    return r ? paraRow(r) : null;
+  },
+
+  // Idempotente de propósito: a plataforma de agentes pode repetir a chamada
+  // (retry de rede, recriar o bot) e o resultado tem que ser o mesmo.
+  gravar(name: string, channel: string, wsToken: string, config: Record<string, any>): TenantRow {
+    db.prepare(
+      `INSERT INTO bridge_tenants (name, channel, ws_token, config, updated_at)
+       VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+       ON CONFLICT(name) DO UPDATE SET
+         channel    = excluded.channel,
+         ws_token   = excluded.ws_token,
+         config     = excluded.config,
+         updated_at = CURRENT_TIMESTAMP`,
+    ).run(name, channel, wsToken, JSON.stringify(config));
+    return this.buscar(name)!;
+  },
+
+  remover(name: string): boolean {
+    return db.prepare("DELETE FROM bridge_tenants WHERE name = ?").run(name).changes > 0;
+  },
+
+  // Dono de um wsToken (pra detectar colisão antes de gravar).
+  donoDoToken(wsToken: string): string | null {
+    const r = db.prepare("SELECT name FROM bridge_tenants WHERE ws_token = ?").get(wsToken) as any;
+    return r ? (r.name as string) : null;
+  },
+};

--- a/src/bridge/ws.ts
+++ b/src/bridge/ws.ts
@@ -39,6 +39,18 @@ export function attachBridgeWebSocket(server: Server): void {
     bridgeHub.registrar(name, socket);
     socket.send(JSON.stringify({ type: "welcome", tenant: name }));
 
+    // Keepalive: ping a cada 30s pra não deixar o ALB derrubar a conexão idle
+    // (idle timeout ~60s). Sem isso a ponte cai/reconecta e mensagem no gap se perde.
+    const pingTimer = setInterval(() => {
+      if (socket.readyState === 1) {
+        try {
+          socket.ping();
+        } catch {
+          /* socket morrendo — o close handler limpa */
+        }
+      }
+    }, 30_000);
+
     socket.on("message", (raw) => {
       let msg: any;
       try {
@@ -49,8 +61,12 @@ export function attachBridgeWebSocket(server: Server): void {
       if (msg?.type === "send") void enviar(name, msg, socket);
     });
 
-    socket.on("close", () => bridgeHub.remover(name, socket));
-    socket.on("error", () => bridgeHub.remover(name, socket));
+    const cleanup = () => {
+      clearInterval(pingTimer);
+      bridgeHub.remover(name, socket);
+    };
+    socket.on("close", cleanup);
+    socket.on("error", cleanup);
   });
 
   console.log("[bridge.ws] ponte WebSocket em /bridge/agent");

--- a/src/env.ts
+++ b/src/env.ts
@@ -18,5 +18,10 @@ export const env = z
     // channel = "whatsapp" | "teams". config varia por canal (ver src/bridge/config.ts).
     // Ex: {"sac":{"wsToken":"tok-sac","channel":"whatsapp","config":{"verifyToken":"...","phoneNumberId":"1202...","metaToken":"EAA..."}}}
     BRIDGE_TENANTS: z.string().default("{}"),
+    // Token que autoriza CRIAR/REMOVER tenant em runtime (rotas
+    // /bridge/tenants/*). Quem chama é o control-plane da plataforma de agentes,
+    // ao provisionar um bot novo. VAZIO = rotas desligadas (fail-closed): sem
+    // token não existe registro em runtime, só o que vem do BRIDGE_TENANTS.
+    BRIDGE_ADMIN_TOKEN: z.string().default(""),
   })
   .parse(process.env);

--- a/src/env.ts
+++ b/src/env.ts
@@ -22,6 +22,17 @@ export const env = z
     // /bridge/tenants/*). Quem chama é o control-plane da plataforma de agentes,
     // ao provisionar um bot novo. VAZIO = rotas desligadas (fail-closed): sem
     // token não existe registro em runtime, só o que vem do BRIDGE_TENANTS.
-    BRIDGE_ADMIN_TOKEN: z.string().default(""),
+    //
+    // Piso de 24 chars quando presente: comprometer esse token dá controle sobre
+    // criar/rotacionar/remover qualquer tenant de runtime, e sem piso um valor
+    // curto escolhido às pressas passaria calado. Falhar no boot é melhor que
+    // subir com uma credencial fraca guardando essa porta — e o wsToken, que é
+    // menos poderoso, já exigia 16.
+    BRIDGE_ADMIN_TOKEN: z
+      .string()
+      .default("")
+      .refine((v) => v === "" || v.length >= 24, {
+        message: "BRIDGE_ADMIN_TOKEN muito curto (mínimo 24 caracteres) — use algo como `openssl rand -hex 24`",
+      }),
   })
   .parse(process.env);


### PR DESCRIPTION
Linha de trabalho da ponte do gateway. Fecha a issue #16.

## O problema que fecha

Um tenant só nascia de `BRIDGE_TENANTS`, lido **uma vez no boot**. Criar um bot novo exigia editar a env e **reiniciar o gateway** — e reiniciar derruba a ponte de todos os bots no ar, além de dar alguns segundos de indisponibilidade no WhatsApp de cliente.

Ou seja: um reinício **por bot**, pra sempre. Esta PR troca isso por um reinício **único** — o desta subida.

```
PUT    /bridge/tenants/:name   cria ou atualiza (idempotente)
DELETE /bridge/tenants/:name   remove
GET    /bridge/tenants         lista nome, canal e origem
GET    /bridge/tenants/:name   existe? de onde vem? tem ponte aberta?
```

O control-plane chama o PUT no último passo do provisionamento do bot, e o bot responde na hora.

## Por que dá pra subir isso num serviço com tráfego de cliente

**Tenant do env é intocável.** `BRIDGE_TENANTS` tem precedência sobre o banco. Sobrescrever, remover ou roubar o `wsToken` do `sac` respondem 409. É o que impede um bot novo de herdar o WhatsApp de produção do SAC — a rota é autenticada por um token só, então essa fronteira não pode depender de boa-fé.

**Fail-closed.** Sem `BRIDGE_ADMIN_TOKEN` as rotas respondem 503 e o comportamento é exatamente o de antes.

**Revogação efetiva.** Trocar o `wsToken` ou remover o tenant FECHA as conexões já autenticadas com a credencial antiga. Sem isso, "revogar" não revogava: a conexão velha seguia aberta recebendo mensagens até o processo reiniciar.

**Não vira ponto único de falha.** Se a tabela nova não puder ser criada (disco cheio, sqlite corrompido), o gateway loga e segue em modo "só env" em vez de não subir — os tenants de produção não dependem dela pra nada.

**Persistência.** Tabela `bridge_tenants` no sqlite existente, que vive no bind-mount `./db:/app/db` — sobrevive a recreate do container.

## Achados da revisão de segurança

Dois revisores passaram antes disto vir pra cá. O que acharam e o que foi feito:

| Sev | Achado | Correção |
|---|---|---|
| HIGH | Outro bot podia tomar um nome de tenant ocupado — o PUT idempotente sobrescrevia as credenciais do dono e derrubava a conexão dele, reportando sucesso | Tenant amarrado à identidade do canal (`appId`/`phoneNumberId`). Mesma identidade atualiza; outra é 409 |
| HIGH | Sem freio de força-bruta e sem piso de entropia no token admin | 24 chars mínimos no env + janela deslizante por IP (10 falhas/60s → 429, com log) |
| HIGH | `GET /bridge/status` entregava os nomes dos bots sem auth | Sem token devolve só a contagem; com token, o detalhe |
| MEDIUM | `OBRIGATORIOS[channel]` resolvia pela cadeia de protótipo — `channel="__proto__"` escapava da checagem de canal desconhecido (CWE-1321) | `Object.hasOwn` |
| MEDIUM | `wsToken` numérico passava na validação (`.length` de número é `undefined`) | Exige string; config precisa ser objeto com campos string |
| MEDIUM | `CREATE TABLE` sem try/catch no boot podia derrubar o serviço inteiro | Captura, loga, segue em modo "só env" |
| MEDIUM | Sem teto de corpo e sem teto de tenants | 16KB e 200 tenants |

### Duas decisões de desenho que vale ler

**A ordem "confere token → depois olha bloqueio".** Invertida, alguém errando de propósito 10 vezes trancaria o control-plane por um minuto — e atrás de proxy/NAT todo mundo vem do mesmo IP, então a proteção contra força-bruta viraria uma negação de serviço trivial sobre criar bot. Força-bruta nunca chega a acertar, então liberar o acerto não enfraquece nada. Tem teste.

**O teto de corpo tem duas checagens.** Eu havia checado só o header `content-length` — que é **opcional**. Requisição com `transfer-encoding: chunked` não manda o header e passava direto pelo limite. O próprio teste encontrou isso. O header ficou como atalho (corta antes de ler bytes); a checagem real é sobre o que chegou.

## Testes

**34**, todos passando. Não havia nenhum antes.

- `config.test.ts` (23) — precedência do env, revogação, colisão de identidade, validação
- `controller.test.ts` (11) — as **rotas HTTP**: a camada que decide 401/429/503/413 antes de qualquer regra de negócio rodar, e que não tinha cobertura nenhuma

```
pnpm test
```

Typecheck limpo nos arquivos do bridge (os erros restantes em `session.ts` e `index.ts` são pré-existentes).

## Verificado ponta a ponta local

Criar tenant sem reiniciar · agente conectar com o token novo · token errado rejeitado (close 4001) · tentar roubar o tenant do SAC (409) · outro `appId` no mesmo nome (409) · mesmo `appId` rotacionando senha (200) · `__proto__` (400) · corpo grande (413) · 10 falhas → 429 com o token bom ainda passando · matar o gateway e ver os dois agentes voltarem sozinhos.

## Antes do merge

`BRIDGE_ADMIN_TOKEN` precisa ser o **mesmo valor** nos secrets dos dois repos (`wa-gateway` e `agent-platform`) — já gravado nos dois. Valor diferente = o control-plane toma 401 e o bot novo nasce sem ponte.

O deploy desta PR é o **último reinício** que derruba a ponte. Combinar janela.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
