### PR TITLE
fix(build): Node 22 na imagem — pnpm 11 não roda em Node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Multi-stage build for WhatsApp Gateway
-FROM node:20-alpine AS base
+# Node 22: o pnpm 11 (fixado no packageManager) usa módulo builtin que não
+# existe no Node 20 — o build da imagem quebrava com ERR_UNKNOWN_BUILTIN_MODULE.
+# Casado com o node-version do CI.
+FROM node:22-alpine AS base
 
 # Install pnpm
 # Versão FIXA: `npm i -g pnpm` pega a latest, então dois builds em datas


### PR DESCRIPTION
O deploy de produção falhou no build da imagem com `ERR_UNKNOWN_BUILTIN_MODULE` (Node v20.20.2).

Erro meu: fixei o pnpm em 11.1.3 pra estabilizar a resolução de dependências, sem conferir que a imagem roda `node:20-alpine`. O pnpm 11 usa um builtin que só existe a partir do Node 22.

**Nada foi pra produção** — a falha foi no build, o container antigo seguiu servindo (health 200 durante toda a janela).

Node 22 é a mesma versão do CI e o Baileys exige >=20. Verificado com `docker build` completo local, incluindo o estágio de produção.